### PR TITLE
Add premium lock for forecast chart

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -183,7 +183,7 @@ def llm_analyze():
 # Basit çok günlü fiyat tahmini endpoint'i
 @api_bp.route('/forecast/<string:coin_id>', methods=['GET'])
 @current_app.limit("60/minute", key_func=lambda: request.headers.get('X-API-KEY') or request.remote_addr)
-@require_subscription_plan(SubscriptionPlan.BASIC)
+@require_subscription_plan(SubscriptionPlan.PREMIUM)
 def forecast_coin(coin_id):
     """Return Prophet based forecast data for the requested coin."""
     user = g.user  # get user from decorator

--- a/frontend/frontend-crypto-analysis-dashboard..html
+++ b/frontend/frontend-crypto-analysis-dashboard..html
@@ -358,7 +358,7 @@
                 </div>
                 <div class="card p-6">
                     <h3 class="text-xl font-bold mb-3 text-white">7 Günlük Tahmin</h3>
-                    <div class="chart-container bg-slate-800 border border-slate-700 rounded-lg overflow-hidden">
+                    <div id="forecastChartContainer" class="chart-container bg-slate-800 border border-slate-700 rounded-lg overflow-hidden">
                         <canvas id="forecastChart"></canvas>
                     </div>
                     <p class="text-sm text-slate-400 mt-4 text-center">Yapay zeka tahmini fiyat eğilimi.</p>
@@ -423,6 +423,7 @@
         const priceChartCanvas = document.getElementById('priceChart');
         let priceChartInstance;
         const forecastChartCanvas = document.getElementById('forecastChart');
+        const forecastChartContainer = document.getElementById('forecastChartContainer');
         let forecastChartInstance;
 
         const backendChartImage = document.getElementById('backend-chart-image');
@@ -647,6 +648,7 @@
         }
 
         async function fetchForecast(coin) {
+            if (USER_SUBSCRIPTION_LEVEL !== 'premium') return;
             try {
                 const resp = await fetch(`${BACKEND_FORECAST_API_URL}${coin}?days=7`, {
                     headers: { 'X-API-KEY': USER_API_KEY }
@@ -790,6 +792,11 @@
                     if (cryptoSelect.value !== 'bitcoin' && cryptoSelect.value !== 'ethereum') {
                         cryptoSelect.value = 'bitcoin';
                     }
+                }
+
+                // PRO olmayanlar için 7 günlük tahmin grafiğini kilitle
+                if (USER_SUBSCRIPTION_LEVEL !== 'premium') {
+                    forecastChartContainer.innerHTML = "<div class='text-center text-slate-400 italic'>Bu özellik yalnızca PRO kullanıcılar için aktiftir.<br><a href='abonelik.html' class='underline font-semibold'>Aboneliği Yükselt</a></div>";
                 }
 
                 // Sticky reminder bar'ı kontrol et ve göster

--- a/tests/test_forecast_api.py
+++ b/tests/test_forecast_api.py
@@ -14,7 +14,7 @@ def setup_user(app):
             role = Role(name="user")
             db.session.add(role)
             db.session.commit()
-        user = User(username="forecast", api_key="fkey", role_id=role.id, subscription_level=SubscriptionPlan.BASIC)
+        user = User(username="forecast", api_key="fkey", role_id=role.id, subscription_level=SubscriptionPlan.PREMIUM)
         user.set_password("pass")
         db.session.add(user)
         db.session.commit()


### PR DESCRIPTION
## Summary
- require premium subscription for forecast API
- gate 7-day forecast chart in dashboard for non-premium users
- adjust tests to use premium plan

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686802e8479c832fbe848a0e15fa82af