### PR TITLE
Implement subscription checks and upgrade API

### DIFF
--- a/backend/tasks/celery_tasks.py
+++ b/backend/tasks/celery_tasks.py
@@ -149,7 +149,12 @@ def check_and_downgrade_subscriptions():
         db.session.commit()
 
 
+from backend.utils.alarms import send_alarm, AlarmSeverityEnum
+
 @celery_app.task
-def send_security_alert_task(message: str):
+def send_security_alert_task(alert_type: str, details: str = "", severity: str = "INFO"):
     """Send a security alert to external channels."""
-    logger.warning(f"Security alert: {message}")
+    logger.warning(f"Security alert: {alert_type} - {details}")
+    with app.app_context():
+        sev = AlarmSeverityEnum[severity] if isinstance(severity, str) else severity
+        send_alarm(alert_type, sev, details)

--- a/frontend/abonelik.html
+++ b/frontend/abonelik.html
@@ -233,6 +233,38 @@
             <div id="subscription-warning" class="warning-box hidden">
                 <!-- Deneme süresi uyarısı buraya gelecek -->
             </div>
+            <div class="overflow-x-auto mt-6">
+                <table class="min-w-full text-sm text-center text-slate-200">
+                    <thead>
+                        <tr>
+                            <th class="border px-2 py-1">Özellik</th>
+                            <th class="border px-2 py-1">TRIAL</th>
+                            <th class="border px-2 py-1">BASIC</th>
+                            <th class="border px-2 py-1">PREMIUM</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="border px-2 py-1">RSI/MACD Analizi</td>
+                            <td class="border">✗</td>
+                            <td class="border">✓</td>
+                            <td class="border">✓</td>
+                        </tr>
+                        <tr>
+                            <td class="border px-2 py-1">LLM Analizleri</td>
+                            <td class="border">✗</td>
+                            <td class="border">✗</td>
+                            <td class="border">✓</td>
+                        </tr>
+                        <tr>
+                            <td class="border px-2 py-1">Anlık Alarm Bildirimleri</td>
+                            <td class="border">✗</td>
+                            <td class="border">✗</td>
+                            <td class="border">✓</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </section>
 
         <div class="grid grid-cols-1 md:grid-cols-3 gap-8">

--- a/frontend/frontend-crypto-analysis-dashboard..html
+++ b/frontend/frontend-crypto-analysis-dashboard..html
@@ -648,7 +648,10 @@
         }
 
         async function fetchForecast(coin) {
-            if (USER_SUBSCRIPTION_LEVEL !== 'premium') return;
+            if (USER_SUBSCRIPTION_LEVEL !== 'premium') {
+                alert("Bu özellik yalnızca Premium abonelikte kullanılabilir. Lütfen aboneliğinizi yükseltin.");
+                return;
+            }
             try {
                 const resp = await fetch(`${BACKEND_FORECAST_API_URL}${coin}?days=7`, {
                     headers: { 'X-API-KEY': USER_API_KEY }

--- a/tests/test_upgrade_api.py
+++ b/tests/test_upgrade_api.py
@@ -1,0 +1,29 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from backend import create_app, db
+from backend.db.models import User, Role, SubscriptionPlan
+
+
+def setup_user(app, plan=SubscriptionPlan.BASIC):
+    with app.app_context():
+        role = Role.query.filter_by(name="user").first()
+        user = User(username="upgrader", api_key="upkey", role_id=role.id, subscription_level=plan)
+        user.set_password("pass")
+        db.session.add(user)
+        db.session.commit()
+    return user
+
+
+def test_upgrade_plan_success(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    app = create_app()
+    client = app.test_client()
+    user = setup_user(app)
+    resp = client.patch(f"/api/users/{user.id}/upgrade_plan", json={"plan": "ADVANCED"}, headers={"X-API-KEY": user.api_key})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["subscription_level"] == "ADVANCED"
+    with app.app_context():
+        updated = User.query.get(user.id)
+        assert updated.subscription_level == SubscriptionPlan.ADVANCED


### PR DESCRIPTION
## Summary
- add premium WebSocket auth and alert emission
- expose technical indicators endpoint
- allow users to upgrade plan via API
- show warning for premium feature on frontend
- add plan comparison table
- add tests for upgrade API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6868081ee858832fb342f105430e113f