### PR TITLE
Add admin plan HTML page

### DIFF
--- a/frontend/admin-planlar.html
+++ b/frontend/admin-planlar.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Abonelik Planları | Admin Panel</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; }
+    .btn { @apply px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition; }
+    .btn-danger { @apply bg-red-600 hover:bg-red-700; }
+    .table th, .table td { @apply px-4 py-2 text-center border; }
+  </style>
+</head>
+<body class="bg-gray-100 min-h-screen p-6">
+  <div class="max-w-6xl mx-auto bg-white p-6 rounded shadow">
+    <div class="flex justify-between items-center mb-4">
+      <h1 class="text-2xl font-bold">Abonelik Planları</h1>
+      <button class="btn" onclick="openModal()">+ Yeni Plan</button>
+    </div>
+    <table class="table w-full border border-gray-300">
+      <thead class="bg-gray-200">
+        <tr>
+          <th>Plan Adı</th>
+          <th>Süre (gün)</th>
+          <th>Fiyat ($)</th>
+          <th>Aktif mi?</th>
+          <th>Açıklama</th>
+          <th>İşlemler</th>
+        </tr>
+      </thead>
+      <tbody id="plan-table-body">
+        <!-- JS ile doldurulacak -->
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Modal -->
+  <div id="planModal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center">
+    <div class="bg-white p-6 rounded w-full max-w-md">
+      <h2 class="text-lg font-semibold mb-4" id="modalTitle">Yeni Plan</h2>
+      <form id="planForm">
+        <input type="hidden" id="plan-id">
+        <div class="mb-3">
+          <label>Plan Adı</label>
+          <input type="text" id="plan-name" class="w-full border px-3 py-2 rounded" required>
+        </div>
+        <div class="mb-3">
+          <label>Süre (gün)</label>
+          <input type="number" id="plan-duration" class="w-full border px-3 py-2 rounded" required>
+        </div>
+        <div class="mb-3">
+          <label>Fiyat ($)</label>
+          <input type="number" step="0.01" id="plan-price" class="w-full border px-3 py-2 rounded" required>
+        </div>
+        <div class="mb-3">
+          <label>Açıklama</label>
+          <textarea id="plan-description" class="w-full border px-3 py-2 rounded"></textarea>
+        </div>
+        <div class="mb-3">
+          <label>
+            <input type="checkbox" id="plan-active">
+            Aktif
+          </label>
+        </div>
+        <div class="flex justify-end space-x-2">
+          <button type="button" onclick="closeModal()" class="btn bg-gray-400 hover:bg-gray-500">İptal</button>
+          <button type="submit" class="btn">Kaydet</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script>
+    const modal = document.getElementById('planModal');
+    const form = document.getElementById('planForm');
+
+    function openModal(plan = null) {
+      modal.classList.remove('hidden');
+      if (plan) {
+        document.getElementById('modalTitle').innerText = 'Planı Düzenle';
+        document.getElementById('plan-id').value = plan.id;
+        document.getElementById('plan-name').value = plan.name;
+        document.getElementById('plan-duration').value = plan.duration;
+        document.getElementById('plan-price').value = plan.price;
+        document.getElementById('plan-description').value = plan.description;
+        document.getElementById('plan-active').checked = plan.active;
+      } else {
+        form.reset();
+      }
+    }
+
+    function closeModal() {
+      modal.classList.add('hidden');
+      form.reset();
+    }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const id = document.getElementById('plan-id').value;
+      const data = {
+        name: document.getElementById('plan-name').value,
+        duration: parseInt(document.getElementById('plan-duration').value),
+        price: parseFloat(document.getElementById('plan-price').value),
+        description: document.getElementById('plan-description').value,
+        active: document.getElementById('plan-active').checked
+      };
+      const method = id ? 'PATCH' : 'POST';
+      const url = id ? `/admin/api/plans/${id}` : '/admin/api/plans';
+      const resp = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (resp.ok) {
+        loadPlans();
+        closeModal();
+      } else {
+        alert('Hata oluştu.');
+      }
+    });
+
+    async function loadPlans() {
+      const tbody = document.getElementById('plan-table-body');
+      tbody.innerHTML = '';
+      const res = await fetch('/admin/api/plans');
+      const plans = await res.json();
+      for (let plan of plans) {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${plan.name}</td>
+          <td>${plan.duration}</td>
+          <td>$${plan.price.toFixed(2)}</td>
+          <td>${plan.active ? '✅' : '❌'}</td>
+          <td>${plan.description || '-'}</td>
+          <td>
+            <button onclick='openModal(${JSON.stringify(plan)})' class="text-indigo-600 font-bold">✏️</button>
+            <button onclick='deletePlan(${plan.id})' class="text-red-600 font-bold ml-2">🗑️</button>
+          </td>`;
+        tbody.appendChild(row);
+      }
+    }
+
+    async function deletePlan(id) {
+      if (!confirm('Bu planı silmek istediğinize emin misiniz?')) return;
+      const res = await fetch(`/admin/api/plans/${id}`, { method: 'DELETE' });
+      if (res.ok) loadPlans();
+    }
+
+    document.addEventListener('DOMContentLoaded', loadPlans);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an admin HTML page for managing subscription plans

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686825701aa8832faad9cd66c9a04810