### PR TITLE
Add admin plans page

### DIFF
--- a/frontend/admin/plans.html
+++ b/frontend/admin/plans.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <title>Abonelik Planları Yönetimi</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-900 text-white">
+
+  <header class="p-4 bg-slate-800 border-b border-slate-700">
+    <h1 class="text-xl font-bold">Admin Panel - Plan Yönetimi</h1>
+  </header>
+
+  <main class="p-6 max-w-4xl mx-auto">
+    <section class="mb-6">
+      <h2 class="text-lg font-semibold mb-2">Yeni Plan Ekle</h2>
+      <div class="grid grid-cols-2 gap-4">
+        <input id="plan-name" type="text" placeholder="Plan Adı" class="input" />
+        <input id="plan-price" type="number" placeholder="Fiyat ($)" class="input" />
+        <input id="plan-duration" type="number" placeholder="Süre (gün)" class="input" />
+        <input id="plan-description" type="text" placeholder="Açıklama" class="input" />
+        <button onclick="createPlan()" class="bg-green-600 hover:bg-green-700 px-4 py-2 rounded">Ekle</button>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="text-lg font-semibold mb-4">Tüm Planlar</h2>
+      <div id="plans-list" class="space-y-4"></div>
+    </section>
+  </main>
+
+  <script>
+    const API_BASE = "http://localhost:5000/admin/api/plans";
+    const JWT_TOKEN = sessionStorage.getItem("admin_jwt");
+
+    function fetchPlans() {
+      fetch(API_BASE + "/", {
+        headers: { "Authorization": "Bearer " + JWT_TOKEN }
+      })
+      .then(res => res.json())
+      .then(data => {
+        const list = document.getElementById("plans-list");
+        list.innerHTML = "";
+        data.forEach(plan => {
+          list.innerHTML += `
+            <div class="p-4 bg-slate-800 border border-slate-700 rounded">
+              <div class="flex justify-between">
+                <div>
+                  <p class="font-semibold text-white">${plan.name}</p>
+                  <p class="text-slate-400 text-sm">Fiyat: $${plan.price} | Süre: ${plan.duration_days} gün</p>
+                  <p class="text-slate-500 text-sm">${plan.description}</p>
+                </div>
+                <div class="flex space-x-2">
+                  <button onclick="deletePlan(${plan.id})" class="bg-red-600 hover:bg-red-700 px-3 py-1 rounded">Sil</button>
+                </div>
+              </div>
+            </div>
+          `;
+        });
+      });
+    }
+
+    function createPlan() {
+      const payload = {
+        name: document.getElementById("plan-name").value,
+        price: parseFloat(document.getElementById("plan-price").value),
+        duration_days: parseInt(document.getElementById("plan-duration").value),
+        description: document.getElementById("plan-description").value,
+        is_active: true
+      };
+
+      fetch(API_BASE + "/", {
+        method: "POST",
+        headers: {
+          "Authorization": "Bearer " + JWT_TOKEN,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      })
+      .then(res => {
+        if (res.ok) {
+          alert("Plan eklendi");
+          fetchPlans();
+        } else {
+          alert("Hata oluştu");
+        }
+      });
+    }
+
+    function deletePlan(id) {
+      if (!confirm("Plan silinsin mi?")) return;
+
+      fetch(API_BASE + "/" + id, {
+        method: "DELETE",
+        headers: { "Authorization": "Bearer " + JWT_TOKEN }
+      })
+      .then(res => {
+        if (res.ok) {
+          alert("Silindi");
+          fetchPlans();
+        }
+      });
+    }
+
+    window.onload = fetchPlans;
+  </script>
+
+  <style>
+    .input {
+      background-color: #1e293b;
+      border: 1px solid #334155;
+      color: white;
+      padding: 0.5rem;
+      border-radius: 0.375rem;
+      width: 100%;
+    }
+  </style>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `frontend/admin/plans.html` for admin plan management

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686827dd8b40832fb2fde872351603ed