### PR TITLE
Add edit modal for plans

### DIFF
--- a/frontend/admin/plans.html
+++ b/frontend/admin/plans.html
@@ -25,9 +25,25 @@
 
     <section>
       <h2 class="text-lg font-semibold mb-4">Tüm Planlar</h2>
-      <div id="plans-list" class="space-y-4"></div>
+  <div id="plans-list" class="space-y-4"></div>
     </section>
   </main>
+
+  <!-- Düzenleme Modali -->
+  <div id="edit-modal" class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center hidden">
+    <div class="bg-slate-800 p-6 rounded shadow-xl w-full max-w-md">
+      <h3 class="text-lg font-semibold mb-4">Planı Düzenle</h3>
+      <input id="edit-plan-id" type="hidden" />
+      <input id="edit-plan-name" type="text" class="input mb-2" placeholder="Plan Adı" />
+      <input id="edit-plan-price" type="number" class="input mb-2" placeholder="Fiyat ($)" />
+      <input id="edit-plan-duration" type="number" class="input mb-2" placeholder="Süre (gün)" />
+      <input id="edit-plan-description" type="text" class="input mb-4" placeholder="Açıklama" />
+      <div class="flex justify-end space-x-2">
+        <button onclick="closeEditModal()" class="bg-gray-600 px-4 py-2 rounded">İptal</button>
+        <button onclick="submitEdit()" class="bg-blue-600 px-4 py-2 rounded">Güncelle</button>
+      </div>
+    </div>
+  </div>
 
   <script>
     const API_BASE = "http://localhost:5000/admin/api/plans";
@@ -51,6 +67,7 @@
                   <p class="text-slate-500 text-sm">${plan.description}</p>
                 </div>
                 <div class="flex space-x-2">
+                  <button onclick="openEditModal(${plan.id}, '${plan.name}', ${plan.price}, ${plan.duration_days}, \`${plan.description}\` )" class="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded">Düzenle</button>
                   <button onclick="deletePlan(${plan.id})" class="bg-red-600 hover:bg-red-700 px-3 py-1 rounded">Sil</button>
                 </div>
               </div>
@@ -83,6 +100,47 @@
           fetchPlans();
         } else {
           alert("Hata oluştu");
+        }
+      });
+    }
+
+    function openEditModal(id, name, price, duration, description) {
+      document.getElementById("edit-plan-id").value = id;
+      document.getElementById("edit-plan-name").value = name;
+      document.getElementById("edit-plan-price").value = price;
+      document.getElementById("edit-plan-duration").value = duration;
+      document.getElementById("edit-plan-description").value = description;
+      document.getElementById("edit-modal").classList.remove("hidden");
+    }
+
+    function closeEditModal() {
+      document.getElementById("edit-modal").classList.add("hidden");
+    }
+
+    function submitEdit() {
+      const id = document.getElementById("edit-plan-id").value;
+      const payload = {
+        name: document.getElementById("edit-plan-name").value,
+        price: parseFloat(document.getElementById("edit-plan-price").value),
+        duration_days: parseInt(document.getElementById("edit-plan-duration").value),
+        description: document.getElementById("edit-plan-description").value
+      };
+
+      fetch(`${API_BASE}/${id}`, {
+        method: "PATCH",
+        headers: {
+          "Authorization": "Bearer " + JWT_TOKEN,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      })
+      .then(res => {
+        if (res.ok) {
+          alert("Güncelleme başarılı");
+          fetchPlans();
+          closeEditModal();
+        } else {
+          alert("Güncelleme başarısız");
         }
       });
     }


### PR DESCRIPTION
## Summary
- allow editing plans in admin UI
- add modal and JS to send PATCH request

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68682ba0220c832fa16ef357fb16e799