### PR TITLE
Implement plan admin features

### DIFF
--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -320,3 +320,14 @@ class PaymentTransactionLog(db.Model):
     status = Column(String(20), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     user = db.relationship('User', backref='payment_logs', lazy=True)
+
+
+class SubscriptionPlanModel(db.Model):
+    """Dinamik abonelik planlarını saklar."""
+    __tablename__ = 'subscription_plans'
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), unique=True, nullable=False)
+    duration_days = Column(Integer, nullable=False)
+    price = Column(Float, nullable=False)
+    description = Column(Text, nullable=True)
+    is_active = Column(Boolean, default=True, nullable=False)

--- a/frontend/admin-planlar.html
+++ b/frontend/admin-planlar.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Abonelik Planları | Admin Panel</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Inter', sans-serif; }
@@ -34,6 +35,9 @@
         <!-- JS ile doldurulacak -->
       </tbody>
     </table>
+    <div class="mt-6">
+      <canvas id="planUsageChart" height="100"></canvas>
+    </div>
   </div>
 
   <!-- Modal -->
@@ -107,7 +111,7 @@
         active: document.getElementById('plan-active').checked
       };
       const method = id ? 'PATCH' : 'POST';
-      const url = id ? `/admin/api/plans/${id}` : '/admin/api/plans';
+      const url = id ? `/api/admin/plans/${id}` : '/api/admin/plans';
       const resp = await fetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
@@ -121,32 +125,56 @@
       }
     });
 
-    async function loadPlans() {
-      const tbody = document.getElementById('plan-table-body');
-      tbody.innerHTML = '';
-      const res = await fetch('/admin/api/plans');
-      const plans = await res.json();
-      for (let plan of plans) {
-        const row = document.createElement('tr');
-        row.innerHTML = `
-          <td>${plan.name}</td>
-          <td>${plan.duration}</td>
-          <td>$${plan.price.toFixed(2)}</td>
-          <td>${plan.active ? '✅' : '❌'}</td>
-          <td>${plan.description || '-'}</td>
-          <td>
-            <button onclick='openModal(${JSON.stringify(plan)})' class="text-indigo-600 font-bold">✏️</button>
-            <button onclick='deletePlan(${plan.id})' class="text-red-600 font-bold ml-2">🗑️</button>
-          </td>`;
-        tbody.appendChild(row);
-      }
+  async function loadPlans() {
+    const tbody = document.getElementById('plan-table-body');
+    tbody.innerHTML = '';
+    const res = await fetch('/api/admin/plans');
+    const plans = await res.json();
+    for (let plan of plans) {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${plan.name}</td>
+        <td>${plan.duration}</td>
+        <td>$${plan.price.toFixed(2)}</td>
+        <td><input type="checkbox" onchange="togglePlanActive(${plan.id}, this.checked)" ${plan.active ? 'checked' : ''}></td>
+        <td>${plan.description || '-'}</td>
+        <td>
+          <button onclick='openModal(${JSON.stringify(plan)})' class="text-indigo-600 font-bold">✏️</button>
+          <button onclick='deletePlan(${plan.id})' class="text-red-600 font-bold ml-2">🗑️</button>
+        </td>`;
+      tbody.appendChild(row);
     }
+    loadPlanUsage();
+  }
 
-    async function deletePlan(id) {
-      if (!confirm('Bu planı silmek istediğinize emin misiniz?')) return;
-      const res = await fetch(`/admin/api/plans/${id}`, { method: 'DELETE' });
-      if (res.ok) loadPlans();
-    }
+  async function togglePlanActive(id, state) {
+    await fetch(`/api/admin/plans/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_active: state })
+    });
+    loadPlanUsage();
+  }
+
+  async function loadPlanUsage() {
+    const res = await fetch('/api/admin/plans/usage');
+    const data = await res.json();
+    const labels = data.map(d => d.plan);
+    const counts = data.map(d => d.user_count);
+    if (window.planChart) window.planChart.destroy();
+    const ctx = document.getElementById('planUsageChart');
+    window.planChart = new Chart(ctx, {
+      type: 'bar',
+      data: { labels: labels, datasets: [{ label: 'Kullanıcı Sayısı', data: counts, backgroundColor: '#4f46e5' }] },
+      options: { scales: { y: { beginAtZero: true } } }
+    });
+  }
+
+  async function deletePlan(id) {
+    if (!confirm('Bu planı silmek istediğinize emin misiniz?')) return;
+    const res = await fetch(`/api/admin/plans/${id}`, { method: 'DELETE' });
+    if (res.ok) loadPlans();
+  }
 
     document.addEventListener('DOMContentLoaded', loadPlans);
   </script>


### PR DESCRIPTION
## Summary
- add `SubscriptionPlanModel` for dynamic plans
- create CRUD endpoints for plans in admin panel
- show plan usage with Chart.js and toggle plan active state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68682f1add88832fbc2d1c18de8a4f1e