### PR TITLE
Add usage limit decorator and redis client update

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -186,6 +186,7 @@ def llm_analyze():
 @api_bp.route('/forecast/<string:coin_id>', methods=['GET'])
 @current_app.limit("60/minute", key_func=lambda: request.headers.get('X-API-KEY') or request.remote_addr)
 @require_subscription_plan(SubscriptionPlan.PREMIUM)
+@check_usage_limit("forecast")
 def forecast_coin(coin_id):
     """Return Prophet based forecast data for the requested coin."""
     user = g.user  # get user from decorator

--- a/frontend/admin/usage-limits.html
+++ b/frontend/admin/usage-limits.html
@@ -35,7 +35,11 @@
       <input type="hidden" id="limit-id">
       <div class="space-y-3">
         <input id="plan-name" type="text" placeholder="Plan Adı" class="w-full border px-3 py-2 rounded">
-        <input id="feature" type="text" placeholder="Özellik (feature)" class="w-full border px-3 py-2 rounded">
+        <select id="feature" class="w-full border px-3 py-2 rounded">
+          <option value="llm_analyze">LLM Analizi</option>
+          <option value="forecast">Fiyat Tahmini</option>
+          <option value="realtime_alert">Anlık Alarm</option>
+        </select>
         <input id="daily-limit" type="number" placeholder="Günlük Limit" class="w-full border px-3 py-2 rounded">
         <input id="monthly-limit" type="number" placeholder="Aylık Limit" class="w-full border px-3 py-2 rounded">
       </div>


### PR DESCRIPTION
## Summary
- integrate `check_usage_limit` in forecast endpoint and realtime alerts websocket
- register redis client inside `create_app`
- provide dropdown for feature names in admin panel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686844306d00832f80bc1207dab29afa