### PR TITLE
Fix usage limits feature input

### DIFF
--- a/frontend/admin/usage-limits.html
+++ b/frontend/admin/usage-limits.html
@@ -35,11 +35,7 @@
       <input type="hidden" id="limit-id">
       <div class="space-y-3">
         <input id="plan-name" type="text" placeholder="Plan Adı" class="w-full border px-3 py-2 rounded">
-        <select id="feature" class="w-full border px-3 py-2 rounded">
-          <option value="llm_analyze">LLM Analizi</option>
-          <option value="forecast">Fiyat Tahmini</option>
-          <option value="realtime_alert">Anlık Alarm</option>
-        </select>
+          <input id="feature" type="text" placeholder="Özellik (feature)" class="w-full border px-3 py-2 rounded">
         <input id="daily-limit" type="number" placeholder="Günlük Limit" class="w-full border px-3 py-2 rounded">
         <input id="monthly-limit" type="number" placeholder="Aylık Limit" class="w-full border px-3 py-2 rounded">
       </div>


### PR DESCRIPTION
## Summary
- allow custom feature names in the admin usage limits page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68684579a138832fb50b93e37616ac8f