### PR TITLE
Add promo code expiration update API

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -145,11 +145,13 @@ def create_app():
     from backend.api.routes import api_bp
     from backend.admin_panel.routes import admin_bp
     from backend.api.admin.usage_limits import admin_usage_bp
+    from backend.api.admin.promo_codes import admin_promo_bp
 
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
     app.register_blueprint(api_bp, url_prefix='/api')
     app.register_blueprint(admin_bp, url_prefix='/api/admin')
     app.register_blueprint(admin_usage_bp)
+    app.register_blueprint(admin_promo_bp)
 
     # Sağlık Kontrol Endpoint'i
     @app.route('/health', methods=['GET'])

--- a/backend/api/admin/promo_codes.py
+++ b/backend/api/admin/promo_codes.py
@@ -1,0 +1,92 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required
+from backend.auth.middlewares import admin_required
+from backend.db.models import db, PromoCode
+from datetime import datetime, timedelta
+
+admin_promo_bp = Blueprint("admin_promo", __name__, url_prefix="/api/admin/promo-codes")
+
+
+@admin_promo_bp.route("/", methods=["GET"])
+@jwt_required()
+@admin_required()
+def list_promo_codes():
+    codes = PromoCode.query.order_by(PromoCode.created_at.desc()).all()
+    return jsonify([c.to_dict() for c in codes]), 200
+
+
+@admin_promo_bp.route("/", methods=["POST"])
+@jwt_required()
+@admin_required()
+def create_promo_code():
+    data = request.get_json() or {}
+    try:
+        code = PromoCode(
+            code=data["code"].upper(),
+            plan=data["plan"].upper(),
+            duration_days=int(data["duration_days"]),
+            max_uses=int(data["max_uses"]),
+            expires_at=datetime.utcnow() + timedelta(days=int(data.get("expires_in_days", 30))),
+            created_by="admin"
+        )
+        db.session.add(code)
+        db.session.commit()
+        return jsonify(code.to_dict()), 201
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 400
+
+
+@admin_promo_bp.route("/<int:promo_id>", methods=["DELETE"])
+@jwt_required()
+@admin_required()
+def delete_promo_code(promo_id):
+    promo = PromoCode.query.get_or_404(promo_id)
+    db.session.delete(promo)
+    db.session.commit()
+    return jsonify({"message": "Silindi"}), 200
+
+
+@admin_promo_bp.route("/<int:promo_id>", methods=["PATCH"])
+@jwt_required()
+@admin_required()
+def update_promo_code(promo_id):
+    promo = PromoCode.query.get_or_404(promo_id)
+    data = request.get_json() or {}
+    try:
+        if "max_uses" in data:
+            promo.max_uses = int(data["max_uses"])
+        if "duration_days" in data:
+            promo.duration_days = int(data["duration_days"])
+        if "is_active" in data:
+            promo.is_active = bool(data["is_active"])
+        db.session.commit()
+        return jsonify(promo.to_dict()), 200
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 400
+
+
+@admin_promo_bp.route("/<int:promo_id>/expiration", methods=["PATCH"])
+@jwt_required()
+@admin_required()
+def update_promo_expiration(promo_id):
+    promo = PromoCode.query.get_or_404(promo_id)
+    data = request.get_json() or {}
+    expires_at_str = data.get("expires_at")
+    if not expires_at_str:
+        return jsonify({"error": "expires_at field is required"}), 400
+    try:
+        new_date = datetime.fromisoformat(expires_at_str)
+    except ValueError:
+        return jsonify({"error": "Invalid ISO date"}), 400
+    if new_date <= datetime.utcnow():
+        return jsonify({"error": "Expiration must be in the future"}), 400
+    try:
+        promo.expires_at = new_date
+        db.session.commit()
+        return jsonify(promo.to_dict()), 200
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 400
+

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -258,6 +258,21 @@ class PromoCode(db.Model):
     is_single_use_per_user = Column(Boolean, default=False, nullable=False)
     assigned_user = db.relationship('User', backref='assigned_promo_codes', foreign_keys=[assigned_user_id], lazy=True)
 
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "code": self.code,
+            "plan": self.plan.name if self.plan else None,
+            "duration_days": self.duration_days,
+            "max_uses": self.max_uses,
+            "current_uses": self.current_uses,
+            "is_active": self.is_active,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "assigned_user_id": self.assigned_user_id,
+            "is_single_use_per_user": self.is_single_use_per_user,
+        }
+
 class PromoCodeUsage(db.Model):
     __tablename__ = 'promo_code_usages'
     id = Column(Integer, primary_key=True)

--- a/tests/test_admin_promo.py
+++ b/tests/test_admin_promo.py
@@ -1,0 +1,70 @@
+import os
+import sys
+from datetime import datetime, timedelta
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend import create_app, db
+from backend.db.models import PromoCode, SubscriptionPlan, Role, User
+
+
+def setup_admin(app):
+    with app.app_context():
+        role = Role.query.filter_by(name="user").first()
+        admin = User(username="adminuser", api_key="adminkey", role_id=role.id)
+        admin.set_password("pass")
+        # flag expected by admin_required
+        admin.is_admin = True
+        db.session.add(admin)
+        db.session.commit()
+    return admin
+
+
+def create_promo(app):
+    with app.app_context():
+        promo = PromoCode(
+            code="TEST",
+            plan=SubscriptionPlan.BASIC,
+            duration_days=10,
+            max_uses=1,
+            expires_at=datetime.utcnow() + timedelta(days=5),
+        )
+        db.session.add(promo)
+        db.session.commit()
+    return promo
+
+
+def test_update_expiration_success(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setattr("flask_jwt_extended.jwt_required", lambda *a, **k: (lambda f: f))
+    monkeypatch.setattr("backend.auth.middlewares.admin_required", lambda: (lambda f: f))
+    app = create_app()
+    client = app.test_client()
+    setup_admin(app)
+    promo = create_promo(app)
+
+    new_date = datetime.utcnow() + timedelta(days=30)
+    resp = client.patch(
+        f"/api/admin/promo-codes/{promo.id}/expiration",
+        json={"expires_at": new_date.isoformat()},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expires_at"].startswith(new_date.date().isoformat())
+
+
+def test_update_expiration_past_date(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setattr("flask_jwt_extended.jwt_required", lambda *a, **k: (lambda f: f))
+    monkeypatch.setattr("backend.auth.middlewares.admin_required", lambda: (lambda f: f))
+    app = create_app()
+    client = app.test_client()
+    setup_admin(app)
+    promo = create_promo(app)
+
+    past_date = datetime.utcnow() - timedelta(days=1)
+    resp = client.patch(
+        f"/api/admin/promo-codes/{promo.id}/expiration",
+        json={"expires_at": past_date.isoformat()},
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- implement admin blueprint for promo code management
- register promo code blueprint
- expose helper `to_dict` in the `PromoCode` model
- add PATCH route to update promo expiration date
- test promo code expiration update

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68684834ed10832f97d7019c58e19ac3