### PR TITLE
Add promo code admin UI

### DIFF
--- a/frontend/admin/promo-codes.html
+++ b/frontend/admin/promo-codes.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <title>Promosyon Kodları | Admin Panel</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-900 p-6">
+  <div class="max-w-5xl mx-auto">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">Promosyon Kodları</h1>
+      <button onclick="openModal()" class="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700">+ Yeni Kod</button>
+    </div>
+
+    <table class="w-full table-auto border-collapse border border-gray-300">
+      <thead class="bg-gray-200">
+        <tr>
+          <th class="border px-4 py-2">Kod</th>
+          <th class="border px-4 py-2">Plan</th>
+          <th class="border px-4 py-2">Süre</th>
+          <th class="border px-4 py-2">Max Kullanım</th>
+          <th class="border px-4 py-2">Mevcut Kullanım</th>
+          <th class="border px-4 py-2">Aktif?</th>
+          <th class="border px-4 py-2">İşlemler</th>
+        </tr>
+      </thead>
+      <tbody id="promo-table"></tbody>
+    </table>
+  </div>
+
+  <!-- Modal -->
+  <div id="promoModal" class="fixed inset-0 bg-black bg-opacity-40 hidden items-center justify-center">
+    <div class="bg-white p-6 rounded shadow-lg max-w-md w-full">
+      <h2 class="text-xl font-semibold mb-4" id="modalTitle">Yeni Kod</h2>
+      <input type="hidden" id="promo-id">
+      <div class="space-y-3">
+        <input id="code" type="text" placeholder="Kod" class="w-full border px-3 py-2 rounded">
+        <select id="plan" class="w-full border px-3 py-2 rounded">
+          <option value="BASIC">BASIC</option>
+          <option value="ADVANCED">ADVANCED</option>
+          <option value="PREMIUM">PREMIUM</option>
+        </select>
+        <input id="duration" type="number" placeholder="Süre (gün)" class="w-full border px-3 py-2 rounded">
+        <input id="max-uses" type="number" placeholder="Max Kullanım" class="w-full border px-3 py-2 rounded">
+      </div>
+      <div class="mt-4 flex justify-end space-x-2">
+        <button onclick="closeModal()" class="bg-gray-500 text-white px-4 py-2 rounded">İptal</button>
+        <button onclick="submitPromo()" class="bg-blue-600 text-white px-4 py-2 rounded">Kaydet</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const API = '/api/admin/promo-codes';
+    const JWT = sessionStorage.getItem("admin_jwt");
+
+    async function loadPromos() {
+      const res = await fetch(API + '/', {
+        headers: { 'Authorization': 'Bearer ' + JWT }
+      });
+      const promos = await res.json();
+      const table = document.getElementById("promo-table");
+      table.innerHTML = '';
+      for (let p of promos) {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td class="border px-4 py-2">${p.code}</td>
+          <td class="border px-4 py-2">${p.plan}</td>
+          <td class="border px-4 py-2">${p.duration_days}</td>
+          <td class="border px-4 py-2">${p.max_uses}</td>
+          <td class="border px-4 py-2">${p.current_uses}</td>
+          <td class="border px-4 py-2">${p.is_active ? '✅' : '❌'}</td>
+          <td class="border px-4 py-2">
+            <button onclick='editPromo(${JSON.stringify(p)})' class="text-blue-600 font-bold">✏️</button>
+            <button onclick='deletePromo(${p.id})' class="text-red-600 font-bold ml-2">🗑️</button>
+          </td>`;
+        table.appendChild(row);
+      }
+    }
+
+    function openModal() {
+      document.getElementById("promoModal").classList.remove("hidden");
+    }
+
+    function closeModal() {
+      document.getElementById("promoModal").classList.add("hidden");
+      document.getElementById("promo-id").value = '';
+      document.getElementById("code").value = '';
+      document.getElementById("plan").value = 'BASIC';
+      document.getElementById("duration").value = '';
+      document.getElementById("max-uses").value = '';
+    }
+
+    function editPromo(p) {
+      document.getElementById("promo-id").value = p.id;
+      document.getElementById("code").value = p.code;
+      document.getElementById("plan").value = p.plan;
+      document.getElementById("duration").value = p.duration_days;
+      document.getElementById("max-uses").value = p.max_uses;
+      openModal();
+    }
+
+    async function submitPromo() {
+      const id = document.getElementById("promo-id").value;
+      const payload = {
+        code: document.getElementById("code").value,
+        plan: document.getElementById("plan").value,
+        duration_days: parseInt(document.getElementById("duration").value),
+        max_uses: parseInt(document.getElementById("max-uses").value)
+      };
+      const method = id ? 'PATCH' : 'POST';
+      const url = id ? `${API}/${id}` : `${API}/`;
+      const res = await fetch(url, {
+        method,
+        headers: {
+          'Authorization': 'Bearer ' + JWT,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+      if (res.ok) {
+        loadPromos();
+        closeModal();
+      } else {
+        alert("İşlem başarısız");
+      }
+    }
+
+    async function deletePromo(id) {
+      if (!confirm("Silmek istiyor musunuz?")) return;
+      await fetch(`${API}/${id}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': 'Bearer ' + JWT }
+      });
+      loadPromos();
+    }
+
+    document.addEventListener("DOMContentLoaded", loadPromos);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Tailwind-powered admin interface to list and manage promo codes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68684e531408832f93abd5fded74439d