### PR TITLE
Add Turkish plan filter tooltips

### DIFF
--- a/frontend/admin/promo-codes.html
+++ b/frontend/admin/promo-codes.html
@@ -17,9 +17,9 @@
       <label class="mr-2">Plan:</label>
       <select id="filter-plan" onchange="loadPromos()" class="border px-2 py-1 rounded">
         <option value="">Tümü</option>
-        <option value="BASIC">BASIC</option>
-        <option value="ADVANCED">ADVANCED</option>
-        <option value="PREMIUM">PREMIUM</option>
+        <option value="BASIC" title="Temel Plan">BASIC</option>
+        <option value="ADVANCED" title="Gelişmiş Plan">ADVANCED</option>
+        <option value="PREMIUM" title="Premium Plan">PREMIUM</option>
       </select>
 
       <label class="ml-4 mr-2">Durum:</label>


### PR DESCRIPTION
## Summary
- add tooltip translations for plan filter options in admin promo codes page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686854df76bc832fbbda243d1c20cf7e