### PR TITLE
Update promo expiration handling

### DIFF
--- a/frontend/admin/promo-codes.html
+++ b/frontend/admin/promo-codes.html
@@ -159,12 +159,14 @@
 
     async function submitPromo() {
       const id = document.getElementById("promo-id").value;
+      const expiresInput = document.getElementById("expires-at").value;
+      const expiresAt = expiresInput ? new Date(expiresInput).toISOString() : null;
       const payload = {
         code: document.getElementById("code").value,
         plan: document.getElementById("plan").value,
         duration_days: parseInt(document.getElementById("duration").value),
         max_uses: parseInt(document.getElementById("max-uses").value),
-        expires_at: document.getElementById("expires-at").value || null
+        expires_at: expiresAt
       };
       const method = id ? 'PATCH' : 'POST';
       const url = id ? `${API}/${id}` : `${API}/`;


### PR DESCRIPTION
## Summary
- adjust admin promo code page to send `expires_at` as an ISO string

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68694e875ad4832f96e3a8e14225273b