### PR TITLE
Add user_email field for promo codes

### DIFF
--- a/backend/api/admin/promo_codes.py
+++ b/backend/api/admin/promo_codes.py
@@ -29,12 +29,17 @@ def create_promo_code():
             except ValueError:
                 return jsonify({"error": "Ge\u00e7ersiz tarih format\u0131 (expires_at)"}), 400
 
+        user_email = data.get("user_email")
+        if user_email == "":
+            user_email = None
+
         code = PromoCode(
             code=data["code"].upper(),
             plan=data["plan"].upper(),
             duration_days=int(data["duration_days"]),
             max_uses=int(data["max_uses"]),
             expires_at=expires_at,
+            user_email=user_email,
             created_by="admin"
         )
         db.session.add(code)
@@ -68,6 +73,8 @@ def update_promo_code(promo_id):
             promo.duration_days = int(data["duration_days"])
         if "is_active" in data:
             promo.is_active = bool(data["is_active"])
+        if "user_email" in data:
+            promo.user_email = data["user_email"] or None
         if "expires_at" in data:
             if data["expires_at"]:
                 try:

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -255,6 +255,7 @@ class PromoCode(db.Model):
     created_at = Column(DateTime, default=datetime.utcnow)
     expires_at = Column(DateTime, nullable=True)
     assigned_user_id = Column(Integer, ForeignKey('users.id'), nullable=True)
+    user_email = Column(String(120), nullable=True)
     is_single_use_per_user = Column(Boolean, default=False, nullable=False)
     assigned_user = db.relationship('User', backref='assigned_promo_codes', foreign_keys=[assigned_user_id], lazy=True)
 
@@ -270,6 +271,7 @@ class PromoCode(db.Model):
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "expires_at": self.expires_at.isoformat() if self.expires_at else None,
             "assigned_user_id": self.assigned_user_id,
+            "user_email": self.user_email,
             "is_single_use_per_user": self.is_single_use_per_user,
         }
 


### PR DESCRIPTION
## Summary
- include `user_email` column in `PromoCode`
- expose the field via `to_dict`
- handle `user_email` in admin promo code create/update endpoints
- test the new behaviour

## Testing
- `pytest tests/test_promo_codes.py::test_user_email_handling -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686956e1be2c832f8b9864246dd39c8f