### PR TITLE
Add promo code stats endpoint and frontend chart

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -146,12 +146,14 @@ def create_app():
     from backend.admin_panel.routes import admin_bp
     from backend.api.admin.usage_limits import admin_usage_bp
     from backend.api.admin.promo_codes import admin_promo_bp
+    from backend.api.admin.promo_stats import stats_bp
 
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
     app.register_blueprint(api_bp, url_prefix='/api')
     app.register_blueprint(admin_bp, url_prefix='/api/admin')
     app.register_blueprint(admin_usage_bp)
     app.register_blueprint(admin_promo_bp)
+    app.register_blueprint(stats_bp)
 
     # Sağlık Kontrol Endpoint'i
     @app.route('/health', methods=['GET'])

--- a/backend/api/admin/promo_stats.py
+++ b/backend/api/admin/promo_stats.py
@@ -1,0 +1,40 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required
+from backend.auth.middlewares import admin_required
+from backend.db.models import PromoCodeUsage, PromoCode
+from sqlalchemy import func
+from datetime import datetime
+
+stats_bp = Blueprint("promo_stats", __name__)
+
+@stats_bp.route("/api/admin/promo-codes/stats", methods=["GET"])
+@jwt_required()
+@admin_required()
+def promo_usage_stats():
+    start = request.args.get("start_date")
+    end = request.args.get("end_date")
+    try:
+        start_date = datetime.fromisoformat(start) if start else None
+        end_date = datetime.fromisoformat(end) if end else None
+    except Exception:
+        return jsonify({"error": "Tarih formatı geçersiz (YYYY-MM-DD)"}), 400
+
+    q = PromoCodeUsage.query
+    if start_date:
+        q = q.filter(PromoCodeUsage.used_at >= start_date)
+    if end_date:
+        q = q.filter(PromoCodeUsage.used_at <= end_date)
+
+    stats = (
+        q.join(PromoCode, PromoCode.id == PromoCodeUsage.promo_code_id)
+        .with_entities(PromoCode.code, func.count(PromoCodeUsage.id))
+        .group_by(PromoCode.code)
+        .order_by(func.count(PromoCodeUsage.id).desc())
+        .all()
+    )
+
+    result = [
+        {"code": code, "count": count}
+        for code, count in stats
+    ]
+    return jsonify(result)

--- a/frontend/admin/promo-codes.html
+++ b/frontend/admin/promo-codes.html
@@ -31,6 +31,14 @@
       </select>
     </div>
 
+    <div class="my-4 flex items-center space-x-4">
+      <label>Başlangıç:</label>
+      <input type="date" id="filter-start" class="border px-2 py-1 rounded">
+      <label>Bitiş:</label>
+      <input type="date" id="filter-end" class="border px-2 py-1 rounded">
+      <button onclick="loadPromoStats()" class="bg-indigo-600 text-white px-3 py-1 rounded hover:bg-indigo-700">Filtrele</button>
+    </div>
+
     <table class="w-full table-auto border-collapse border border-gray-300">
       <thead class="bg-gray-200">
         <tr>
@@ -50,6 +58,10 @@
 
     <div class="mt-6">
       <canvas id="promoChart" height="100"></canvas>
+    </div>
+
+    <div class="mt-6">
+      <canvas id="promoStatsChart" height="100"></canvas>
     </div>
   </div>
 
@@ -202,7 +214,44 @@
       loadPromos();
     }
 
-    document.addEventListener("DOMContentLoaded", loadPromos);
+    async function loadPromoStats() {
+      const start = document.getElementById("filter-start").value;
+      const end = document.getElementById("filter-end").value;
+
+      let url = "/api/admin/promo-codes/stats";
+      const params = [];
+      if (start) params.push("start_date=" + start);
+      if (end) params.push("end_date=" + end);
+      if (params.length) url += "?" + params.join("&");
+
+      const res = await fetch(url, {
+        headers: { 'Authorization': 'Bearer ' + JWT }
+      });
+      const data = await res.json();
+
+      const labels = data.map(x => x.code);
+      const counts = data.map(x => x.count);
+
+      const ctx = document.getElementById("promoStatsChart");
+      if (window.promoStatsChartInstance) window.promoStatsChartInstance.destroy();
+      window.promoStatsChartInstance = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Kullanım Sayısı',
+            data: counts,
+            backgroundColor: '#10b981'
+          }]
+        },
+        options: { scales: { y: { beginAtZero: true } } }
+      });
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+      loadPromos();
+      loadPromoStats();
+    });
   </script>
 </body>
 </html>

--- a/tests/test_admin_promo.py
+++ b/tests/test_admin_promo.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from backend import create_app, db
-from backend.db.models import PromoCode, SubscriptionPlan, Role, User
+from backend.db.models import PromoCode, PromoCodeUsage, SubscriptionPlan, Role, User
 
 
 def setup_admin(app):
@@ -68,3 +68,34 @@ def test_update_expiration_past_date(monkeypatch):
         json={"expires_at": past_date.isoformat()},
     )
     assert resp.status_code == 400
+
+
+def test_promo_usage_stats(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setattr("flask_jwt_extended.jwt_required", lambda *a, **k: (lambda f: f))
+    monkeypatch.setattr("backend.auth.middlewares.admin_required", lambda: (lambda f: f))
+    app = create_app()
+    client = app.test_client()
+    setup_admin(app)
+
+    with app.app_context():
+        role = Role.query.filter_by(name="user").first()
+        user1 = User(username="u1", api_key="k1", role_id=role.id)
+        user1.set_password("p")
+        user2 = User(username="u2", api_key="k2", role_id=role.id)
+        user2.set_password("p")
+        promo1 = PromoCode(code="CODE1", plan=SubscriptionPlan.BASIC, duration_days=1, max_uses=5)
+        promo2 = PromoCode(code="CODE2", plan=SubscriptionPlan.BASIC, duration_days=1, max_uses=5)
+        db.session.add_all([user1, user2, promo1, promo2])
+        db.session.commit()
+        usage1 = PromoCodeUsage(promo_code_id=promo1.id, user_id=user1.id)
+        usage2 = PromoCodeUsage(promo_code_id=promo1.id, user_id=user2.id)
+        usage3 = PromoCodeUsage(promo_code_id=promo2.id, user_id=user1.id)
+        db.session.add_all([usage1, usage2, usage3])
+        db.session.commit()
+
+    resp = client.get("/api/admin/promo-codes/stats")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert any(d["code"] == "CODE1" and d["count"] == 2 for d in data)
+    assert any(d["code"] == "CODE2" and d["count"] == 1 for d in data)


### PR DESCRIPTION
## Summary
- implement `/api/admin/promo-codes/stats` endpoint
- register new blueprint
- extend promo codes admin page with date filters and stats chart
- add `loadPromoStats` JS helper
- test promo usage stats API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68695e570780832fb20bc60ecac8f48a