### PR TITLE
Add prediction management API

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -150,6 +150,7 @@ def create_app():
     from backend.api.admin.usage_limits import admin_usage_bp
     from backend.api.admin.promo_codes import admin_promo_bp
     from backend.api.admin.promo_stats import stats_bp
+    from backend.api.admin.predictions import predictions_bp
 
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
     app.register_blueprint(api_bp, url_prefix='/api')
@@ -158,6 +159,7 @@ def create_app():
     app.register_blueprint(admin_usage_bp)
     app.register_blueprint(admin_promo_bp)
     app.register_blueprint(stats_bp)
+    app.register_blueprint(predictions_bp)
 
     # Sağlık Kontrol Endpoint'i
     @app.route('/health', methods=['GET'])

--- a/backend/api/admin/predictions.py
+++ b/backend/api/admin/predictions.py
@@ -1,0 +1,95 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required
+from backend.auth.middlewares import admin_required
+from backend.db import db
+from backend.db.models import PredictionOpportunity
+from datetime import datetime
+
+predictions_bp = Blueprint("predictions", __name__, url_prefix="/api/admin/predictions")
+
+
+@predictions_bp.route("/", methods=["GET"])
+@jwt_required()
+@admin_required()
+def list_predictions():
+    predictions = PredictionOpportunity.query.order_by(PredictionOpportunity.created_at.desc()).all()
+    return jsonify([p.to_dict() for p in predictions])
+
+
+@predictions_bp.route("/", methods=["POST"])
+@jwt_required()
+@admin_required()
+def create_prediction():
+    data = request.get_json() or {}
+    try:
+        required_fields = ["symbol", "current_price", "target_price", "expected_gain_pct"]
+        for field in required_fields:
+            if field not in data:
+                return jsonify({"error": f"'{field}' alan\u0131 zorunludur"}), 400
+
+        pred = PredictionOpportunity(
+            symbol=data["symbol"].upper(),
+            current_price=float(data["current_price"]),
+            target_price=float(data["target_price"]),
+            forecast_horizon=data.get("forecast_horizon"),
+            expected_gain_pct=float(data["expected_gain_pct"]),
+            confidence_score=float(data.get("confidence_score", 0.0)),
+            trend_type=data.get("trend_type", "short_term"),
+            source_model=data.get("source_model", "AIModel"),
+            is_active=bool(data.get("is_active", True)),
+            created_at=datetime.utcnow(),
+        )
+        db.session.add(pred)
+        db.session.commit()
+        return jsonify(pred.to_dict()), 201
+    except ValueError as ve:
+        return jsonify({"error": f"Tip uyu\u015fmazl\u0131\u011f\u0131: {str(ve)}"}), 400
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 400
+
+
+@predictions_bp.route("/<int:prediction_id>", methods=["PATCH"])
+@jwt_required()
+@admin_required()
+def update_prediction(prediction_id):
+    data = request.get_json() or {}
+    pred = PredictionOpportunity.query.get_or_404(prediction_id)
+    try:
+        float_fields = ["current_price", "target_price", "expected_gain_pct", "confidence_score"]
+        for field in [
+            "symbol",
+            "current_price",
+            "target_price",
+            "forecast_horizon",
+            "expected_gain_pct",
+            "confidence_score",
+            "trend_type",
+            "source_model",
+            "is_active",
+        ]:
+            if field in data:
+                value = data[field]
+                if field in float_fields:
+                    setattr(pred, field, float(value))
+                elif field == "symbol":
+                    setattr(pred, field, value.upper())
+                else:
+                    setattr(pred, field, value)
+        db.session.commit()
+        return jsonify(pred.to_dict()), 200
+    except ValueError as ve:
+        return jsonify({"error": f"Tip uyu\u015fmazl\u0131\u011f\u0131: {str(ve)}"}), 400
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 400
+
+
+@predictions_bp.route("/<int:prediction_id>", methods=["DELETE"])
+@jwt_required()
+@admin_required()
+def delete_prediction(prediction_id):
+    pred = PredictionOpportunity.query.get_or_404(prediction_id)
+    db.session.delete(pred)
+    db.session.commit()
+    return jsonify({"message": "Silindi"}), 200

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -376,3 +376,36 @@ class UsageLimitModel(db.Model):
             "monthly_limit": self.monthly_limit,
             "created_at": self.created_at.isoformat(),
         }
+
+
+class PredictionOpportunity(db.Model):
+    """Yüksek potansiyelli trade fırsatlarını saklar."""
+
+    __tablename__ = "prediction_opportunities"
+
+    id = Column(Integer, primary_key=True)
+    symbol = Column(String(20), nullable=False, index=True)
+    current_price = Column(Float, nullable=False)
+    target_price = Column(Float, nullable=False)
+    forecast_horizon = Column(String(20), nullable=True)
+    expected_gain_pct = Column(Float, nullable=False)
+    confidence_score = Column(Float, nullable=True)
+    trend_type = Column(String(50), nullable=True)
+    source_model = Column(String(100), nullable=True)
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "symbol": self.symbol,
+            "current_price": self.current_price,
+            "target_price": self.target_price,
+            "forecast_horizon": self.forecast_horizon,
+            "expected_gain_pct": self.expected_gain_pct,
+            "confidence_score": self.confidence_score,
+            "trend_type": self.trend_type,
+            "source_model": self.source_model,
+            "is_active": self.is_active,
+            "created_at": self.created_at.isoformat(),
+        }


### PR DESCRIPTION
## Summary
- add PredictionOpportunity model for admin predictions
- create predictions blueprint for CRUD operations
- register predictions blueprint in app

## Testing
- `pytest -q` *(fails: ImportError for fresh_jwt_required and OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68698d4729d8832fbe5c5a9b14d1c78c