### PR TITLE
Enhance admin prediction security

### DIFF
--- a/tests/test_predictions_api.py
+++ b/tests/test_predictions_api.py
@@ -25,6 +25,7 @@ def test_create_and_list_predictions(monkeypatch):
     monkeypatch.setattr(flask_jwt_extended, "jwt_required", lambda *a, **k: (lambda f: f))
     monkeypatch.setattr(flask_jwt_extended, "fresh_jwt_required", lambda *a, **k: (lambda f: f), raising=False)
     monkeypatch.setattr("backend.auth.middlewares.admin_required", lambda: (lambda f: f))
+    monkeypatch.setattr("backend.auth.jwt_utils.require_csrf", lambda f: f)
     app = create_app()
     client = app.test_client()
 
@@ -62,6 +63,7 @@ def test_update_and_delete_prediction(monkeypatch):
     monkeypatch.setattr(flask_jwt_extended, "jwt_required", lambda *a, **k: (lambda f: f))
     monkeypatch.setattr(flask_jwt_extended, "fresh_jwt_required", lambda *a, **k: (lambda f: f), raising=False)
     monkeypatch.setattr("backend.auth.middlewares.admin_required", lambda: (lambda f: f))
+    monkeypatch.setattr("backend.auth.jwt_utils.require_csrf", lambda f: f)
     app = create_app()
     client = app.test_client()
 


### PR DESCRIPTION
## Summary
- validate prediction data before database insert/update
- hide exception messages from API responses
- enable CSRF checks on admin prediction routes
- adjust tests to patch the new CSRF decorator

## Testing
- `pytest tests/test_predictions_api.py -q`
- `pytest -q` *(fails: assert <SubscriptionPlan.PREMIUM: 3> == <SubscriptionPlan.BASIC: 1> etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6869b82bfe98832f8ec446319b6b249b