### PR TITLE
Add public predictions list and visibility flag

### DIFF
--- a/backend/api/admin/prediction_scheduler.py
+++ b/backend/api/admin/prediction_scheduler.py
@@ -25,6 +25,30 @@ def list_predictions():
     return jsonify([p.to_dict() for p in predictions])
 
 
+@predictions_bp.route("/public", methods=["GET"])
+def public_predictions():
+    """Kullanıcılara açık önerileri listeler."""
+    predictions = (
+        PredictionOpportunity.query
+        .filter_by(is_active=True, is_public=True)
+        .order_by(PredictionOpportunity.created_at.desc())
+        .all()
+    )
+    result = [
+        {
+            "symbol": p.symbol,
+            "target_price": p.target_price,
+            "expected_gain_pct": p.expected_gain_pct,
+            "confidence_score": p.confidence_score,
+            "trend_type": p.trend_type,
+            "forecast_horizon": p.forecast_horizon,
+            "created_at": p.created_at.isoformat(),
+        }
+        for p in predictions
+    ]
+    return jsonify(result), 200
+
+
 @predictions_bp.route("/", methods=["POST"])
 @jwt_required()
 @admin_required()
@@ -46,6 +70,7 @@ def create_prediction():
             trend_type=data.get("trend_type", "short_term"),
             source_model=data.get("source_model", "AIModel"),
             is_active=bool(data.get("is_active", True)),
+            is_public=bool(data.get("is_public", True)),
             created_at=datetime.utcnow()
         )
         db.session.add(pred)
@@ -70,7 +95,7 @@ def update_prediction(prediction_id):
         float_fields = ["current_price", "target_price", "expected_gain_pct", "confidence_score"]
         for field in [
             "symbol", "current_price", "target_price", "forecast_horizon",
-            "expected_gain_pct", "confidence_score", "trend_type", "source_model", "is_active"
+            "expected_gain_pct", "confidence_score", "trend_type", "source_model", "is_active", "is_public"
         ]:
             if field in data:
                 value = data[field]

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -394,6 +394,7 @@ class PredictionOpportunity(db.Model):
     trend_type = Column(String(50), nullable=False, default='short_term')
     source_model = Column(String(100), nullable=False, default='AIModel')
     is_active = Column(Boolean, default=True, nullable=False)
+    is_public = Column(Boolean, default=True, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
     def to_dict(self):
@@ -408,5 +409,6 @@ class PredictionOpportunity(db.Model):
             "trend_type": self.trend_type,
             "source_model": self.source_model,
             "is_active": self.is_active,
+            "is_public": self.is_public,
             "created_at": self.created_at.isoformat(),
         }


### PR DESCRIPTION
## Summary
- allow storing a `is_public` flag for predictions
- expose `/api/admin/predictions/public` endpoint
- support `is_public` in admin prediction APIs
- include APScheduler blueprint update

## Testing
- `pytest tests/test_predictions_api.py -q`
- `pytest -q` *(fails: Subscription and forecast tests)*

------
https://chatgpt.com/codex/tasks/task_e_686a6484542c832fae6a392ba050bb3b