### PR TITLE
Add prediction display UI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Alt klasörler:
 
 ### `frontend/` Klasörü
 
-Ana klasördeki `.html` dosyaları statik sayfalardır: `index.html`, `giris.html`, `kayit.html`, `abonelik.html`, `dashboard.html`, `sifremi-unuttum.html` ve `reset-password.html`. Bunlar Flask tarafından servis edilen basit arayüzleri içerir.
+Ana klasördeki `.html` dosyaları statik sayfalardır: `index.html`, `giris.html`, `kayit.html`, `abonelik.html`, `dashboard.html`, `sifremi-unuttum.html`, `reset-password.html` ve `prediction-display.html`. Bunlar Flask tarafından servis edilen basit arayüzleri içerir.
 
 `static/` klasöründe istemci JavaScript kodları (`api.js`) ve diğer statik varlıklar bulunur.
 
@@ -207,6 +207,7 @@ Ana klasördeki `.html` dosyaları statik sayfalardır: `index.html`, `giris.htm
 │   ├── abonelik.html
 │   ├── abonelik2.html
 │   ├── dashboard.html
+│   ├── prediction-display.html
 │   ├── frontend-crypto-analysis-dashboard
 │   ├── giris.html
 │   ├── homepage-unregistered.html

--- a/backend/frontend/routes.py
+++ b/backend/frontend/routes.py
@@ -5,3 +5,9 @@ from . import frontend_bp
 @frontend_bp.route('/')
 def index():
     return render_template('index.html')
+
+
+@frontend_bp.route('/predictions')
+def prediction_display():
+    """Render the public predictions page."""
+    return render_template('prediction_display.html')

--- a/backend/templates/prediction_display.html
+++ b/backend/templates/prediction_display.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <title>Tahmin Fırsatları</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-900 p-6">
+    <div class="max-w-6xl mx-auto">
+        <h1 class="text-2xl font-bold mb-4">Tahmin Fırsatları</h1>
+        <div class="flex space-x-2 mb-4">
+            <input id="trend-type" type="text" placeholder="Trend tipi" class="border px-3 py-2 rounded">
+            <input id="min-confidence" type="number" placeholder="Min güven" class="border px-3 py-2 rounded">
+            <button onclick="loadPredictions()" class="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700">Yükle</button>
+        </div>
+        <table class="w-full table-auto border-collapse border border-gray-300">
+            <thead class="bg-gray-200">
+                <tr>
+                    <th class="border px-2 py-1">Sembol</th>
+                    <th class="border px-2 py-1">Hedef Fiyat</th>
+                    <th class="border px-2 py-1">Beklenen Getiri %</th>
+                    <th class="border px-2 py-1">Güven %</th>
+                    <th class="border px-2 py-1">Durum</th>
+                    <th class="border px-2 py-1">Kalan Süre</th>
+                </tr>
+            </thead>
+            <tbody id="pred-table"></tbody>
+        </table>
+    </div>
+    <script>
+        async function loadPredictions(page = 1) {
+            const trend = document.getElementById('trend-type').value;
+            const conf = document.getElementById('min-confidence').value;
+            const params = new URLSearchParams({page, per_page: 20});
+            if (trend) params.append('trend_type', trend);
+            if (conf) params.append('min_confidence', conf);
+            const res = await fetch('/api/admin/predictions/public?' + params.toString());
+            const data = await res.json();
+            const tbody = document.getElementById('pred-table');
+            tbody.innerHTML = '';
+            if (!data.items) return;
+            for (const p of data.items) {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td class="border px-2 py-1">${p.symbol}</td>
+                    <td class="border px-2 py-1">${p.target_price}</td>
+                    <td class="border px-2 py-1">${p.expected_gain_pct}</td>
+                    <td class="border px-2 py-1">${p.confidence_score}</td>
+                    <td class="border px-2 py-1">${p.status}</td>
+                    <td class="border px-2 py-1">${p.remaining_time || '-'}</td>
+                `;
+                tbody.appendChild(row);
+            }
+        }
+        document.addEventListener('DOMContentLoaded', () => loadPredictions());
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve a new prediction display page at `/predictions`
- document the new HTML file
- include the template under `backend/templates`

## Testing
- `pytest -q` *(fails: Subscription downgrade logic, forecast API, predictions, promo codes, RBAC, session handling)*

------
https://chatgpt.com/codex/tasks/task_e_686a7d2043dc832f88f3421ca3410052