### PR TITLE
Add offline crypto TA script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Bu proje Flask tabanlı bir kripto para analiz uygulamasıdır. Depo iki ana kı
 * **backend/** - Flask API ve analiz servisleri
 * **frontend/** - Basit HTML arayüzü
 
+Ek olarak `scripts/` dizininde yardımcı araçlar bulunur.
+
+Hızlı bir analiz denemek için `scripts/crypto_ta.py` dosyasını çalıştırabilirsiniz.
+Bu betik CoinGecko servisine erişim olmadığında örnek verilerle teknik
+analiz göstergelerini hesaplar.
+
 Backend klasör yapısı aşağıdaki gibidir:
 
 ```
@@ -184,7 +190,8 @@ Ana klasördeki `.html` dosyaları statik sayfalardır: `index.html`, `giris.htm
 
 - `migrations/` - Alembic tarafından oluşturulacak veritabanı göç dosyaları için yer tutucu.
 - `tests/` - Uygulamanın temel işlevlerini doğrulayan Pytest testleri.
-- `scripts/` - Ortam kurulumuna yardımcı betikler.
+- `scripts/` - Ortam kurulumuna yardımcı betikler. Burada ayrıca `crypto_ta.py`
+  dosyası bulunur ve çevrimdışı modda örnek teknik analiz yapar.
 ### Dizin Yapısı
 
 ```text

--- a/scripts/crypto_ta.py
+++ b/scripts/crypto_ta.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import pandas_ta as ta
+import requests
+
+
+# CoinGecko API üzerinden geçmiş fiyat verisi çekme
+# Proxy restrictions may block network access, so fall back to sample data
+
+def fetch_ohlc_data(coin_id="bitcoin", vs_currency="usd", days=7):
+    """Fetch hourly OHLC data from CoinGecko or return sample data."""
+    url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/market_chart"
+    params = {"vs_currency": vs_currency, "days": days, "interval": "hourly"}
+
+    try:
+        res = requests.get(url, params=params, timeout=10)
+        res.raise_for_status()
+        data = res.json()
+        prices = data.get("prices", [])
+    except Exception:
+        # Offline fallback: generate simple increasing price series
+        prices = []
+        timestamp = pd.Timestamp.utcnow().floor("h") - pd.Timedelta(hours=days * 24)
+        price = 100.0
+        for _ in range(days * 24):
+            prices.append([int(timestamp.timestamp() * 1000), price])
+            timestamp += pd.Timedelta(hours=1)
+            price += 1
+        print("Unable to fetch data from CoinGecko, using sample dataset instead")
+
+    df = pd.DataFrame(prices, columns=["timestamp", "price"])
+    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+    df.set_index("timestamp", inplace=True)
+    return df
+
+
+def calculate_indicators(df):
+    """Calculate RSI and MACD indicators."""
+    df["rsi"] = ta.rsi(df["price"], length=14)
+    macd = ta.macd(df["price"])
+    df = df.join(macd)
+    return df[["price", "rsi", "MACD_12_26_9", "MACDs_12_26_9", "MACDh_12_26_9"]]
+
+
+if __name__ == "__main__":
+    ohlc_data = fetch_ohlc_data("bitcoin", days=7)
+    ta_result = calculate_indicators(ohlc_data)
+    print(ta_result.tail())


### PR DESCRIPTION
## Summary
- add `scripts/crypto_ta.py` for calculating technical indicators
- note new helper script in the README

## Testing
- `pytest -q` *(fails: AttributeError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a8b13e6ac832facb038d66c5692c6