### PR TITLE
Add technical analysis insights

### DIFF
--- a/backend/api/ta_routes.py
+++ b/backend/api/ta_routes.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, jsonify
 from backend.db.models import TechnicalIndicator
+from backend.tasks.strategic_recommender import generate_ta_based_recommendation
 
 bp = Blueprint('ta', __name__)
 
@@ -8,3 +9,11 @@ bp = Blueprint('ta', __name__)
 def latest_ta():
     latest = TechnicalIndicator.query.order_by(TechnicalIndicator.created_at.desc()).first()
     return jsonify(latest.to_dict() if latest else {}), 200
+
+
+@bp.route('/insight/<symbol>', methods=['GET'])
+def technical_insight(symbol):
+    data = generate_ta_based_recommendation(symbol)
+    if not data:
+        return jsonify({"error": "Veri bulunamadı"}), 404
+    return jsonify(data)

--- a/backend/tasks/strategic_recommender.py
+++ b/backend/tasks/strategic_recommender.py
@@ -1,0 +1,34 @@
+from backend.db.models import TechnicalIndicator
+from sqlalchemy import desc
+
+
+def generate_ta_based_recommendation(symbol="bitcoin"):
+    indicator = (
+        TechnicalIndicator.query.filter_by(symbol=symbol.upper())
+        .order_by(desc(TechnicalIndicator.created_at))
+        .first()
+    )
+    if not indicator:
+        return None
+
+    recommendation = []
+    if indicator.rsi is not None:
+        if indicator.rsi < 30:
+            recommendation.append("RSI çok düşük → Aşırı satım bölgesi")
+        elif indicator.rsi > 70:
+            recommendation.append("RSI çok yüksek → Aşırı alım bölgesi")
+
+    if indicator.macd is not None and indicator.signal is not None:
+        if indicator.macd > indicator.signal:
+            recommendation.append("MACD > Signal → Al sinyali")
+        else:
+            recommendation.append("MACD < Signal → Sat sinyali")
+
+    return {
+        "symbol": symbol.upper(),
+        "rsi": round(indicator.rsi, 2) if indicator.rsi is not None else None,
+        "macd": round(indicator.macd, 2) if indicator.macd is not None else None,
+        "signal": round(indicator.signal, 2) if indicator.signal is not None else None,
+        "created_at": indicator.created_at.isoformat(),
+        "insight": recommendation,
+    }

--- a/tests/test_ta_insight.py
+++ b/tests/test_ta_insight.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend import create_app, db
+from backend.db.models import TechnicalIndicator
+from backend.tasks.strategic_recommender import generate_ta_based_recommendation
+
+
+def test_generate_ta_based_recommendation(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    app = create_app()
+    with app.app_context():
+        ti = TechnicalIndicator(symbol="BTC", rsi=20.0, macd=1.5, signal=1.0)
+        db.session.add(ti)
+        db.session.commit()
+        data = generate_ta_based_recommendation("BTC")
+        assert data["symbol"] == "BTC"
+        assert any("Aşırı satım" in msg for msg in data["insight"])


### PR DESCRIPTION
## Summary
- implement TA insight generator
- expose new /insight API endpoint
- add unit test for recommendation utility

## Testing
- `pytest tests/test_ta_insight.py -q`
- `pytest -q` *(fails: AttributeError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ab1e48d04832fafb1d79c95e1a093