### PR TITLE
Add CoinGecko price helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Hızlı bir analiz denemek için `scripts/crypto_ta.py` dosyasını çalıştır
 Bu betik CoinGecko servisine erişim olmadığında örnek verilerle teknik
 analiz göstergelerini hesaplar.
 
+Gerçek zamanlı fiyat bilgisini almak için `backend/utils/price_fetcher.py`
+içindeki `fetch_current_price` fonksiyonu kullanılabilir. Ağ sorunu olduğunda
+fonksiyon `None` döndürür ve görevler bunu ele alacak şekilde tasarlanmıştır.
+
 Backend klasör yapısı aşağıdaki gibidir:
 
 ```

--- a/backend/api/admin/prediction_scheduler.py
+++ b/backend/api/admin/prediction_scheduler.py
@@ -23,6 +23,8 @@ from scripts.crypto_ta import fetch_ohlc_data, calculate_indicators
 import feedparser
 import requests
 
+from backend.utils.price_fetcher import fetch_current_price
+
 predictions_bp = Blueprint("predictions", __name__, url_prefix="/api/admin/predictions")
 logger = logging.getLogger(__name__)
 
@@ -327,7 +329,10 @@ def generate_prediction_from_ta(symbol="bitcoin", threshold_gain: float = 3.0):
     if not rec:
         return None
 
-    current_price = 100  # TODO: gerçek fiyat verisi ile değiştirilmeli
+    current_price = fetch_current_price(symbol)
+    if not current_price:
+        logger.warning("[TA] Gerçek zamanlı fiyat alınamadı")
+        return None
     prediction = PredictionOpportunity(
         symbol=symbol.upper(),
         current_price=current_price,

--- a/backend/utils/price_fetcher.py
+++ b/backend/utils/price_fetcher.py
@@ -1,0 +1,23 @@
+"""Utility function to fetch real-time crypto prices from CoinGecko."""
+
+from __future__ import annotations
+
+import requests
+from loguru import logger
+
+
+def fetch_current_price(symbol: str = "bitcoin", currency: str = "usd") -> float | None:
+    """Return the current price of ``symbol`` in the given ``currency``.
+
+    On any error or network issue ``None`` is returned instead of raising
+    an exception.
+    """
+    url = "https://api.coingecko.com/api/v3/simple/price"
+    params = {"ids": symbol, "vs_currencies": currency}
+    try:
+        res = requests.get(url, params=params, timeout=10)
+        res.raise_for_status()
+        return res.json().get(symbol, {}).get(currency)
+    except Exception as exc:  # pragma: no cover - network calls
+        logger.warning(f"Could not fetch price for {symbol}: {exc}")
+        return None


### PR DESCRIPTION
## Summary
- add `price_fetcher` helper to retrieve real-time prices from CoinGecko
- integrate helper in TA-based prediction scheduler
- document the helper in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: AttributeError in forecast tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_686ac4fa4368832f862f82806641b00e