### PR TITLE
Add bulk TA prediction scheduler

### DIFF
--- a/backend/api/admin/prediction_scheduler.py
+++ b/backend/api/admin/prediction_scheduler.py
@@ -24,6 +24,7 @@ import feedparser
 import requests
 
 from backend.utils.price_fetcher import fetch_current_price
+from backend.tasks.bulk_prediction import generate_predictions_for_all_coins
 
 predictions_bp = Blueprint("predictions", __name__, url_prefix="/api/admin/predictions")
 logger = logging.getLogger(__name__)
@@ -398,4 +399,5 @@ scheduler.add_job(fetch_sentiment_news, 'interval', hours=4, id="sentiment_task"
 scheduler.add_job(evaluate_prediction_success, 'interval', minutes=20, id="evaluate_predictions")
 scheduler.add_job(fetch_and_store_technical_indicators, 'interval', minutes=30, id="technical_analysis")
 scheduler.add_job(lambda: generate_prediction_from_ta("bitcoin"), 'interval', hours=2, id="ta_predictions")
+scheduler.add_job(lambda: generate_predictions_for_all_coins(limit=10), 'interval', hours=6, id="bulk_ta_predictions")
 scheduler.start()

--- a/backend/tasks/bulk_prediction.py
+++ b/backend/tasks/bulk_prediction.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta
+import logging
+
+from pycoingecko import CoinGeckoAPI
+
+from backend.tasks.strategic_recommender import generate_ta_based_recommendation
+from backend.utils.price_fetcher import fetch_current_price
+from backend.db import db
+from backend.db.models import PredictionOpportunity
+
+logger = logging.getLogger(__name__)
+cg = CoinGeckoAPI()
+
+
+def generate_predictions_for_all_coins(limit: int = 5):
+    """Generate TA-based predictions for the most popular coins."""
+    try:
+        coins = cg.get_coins_markets(vs_currency="usd", per_page=limit, page=1)
+        symbols = [coin["id"] for coin in coins]
+
+        created: list[str] = []
+        for sym in symbols:
+            data = generate_ta_based_recommendation(symbol=sym)
+            if not data:
+                continue
+            current_price = fetch_current_price(sym)
+            if current_price is None:
+                continue
+            pred = PredictionOpportunity(
+                symbol=data["symbol"],
+                current_price=current_price,
+                target_price=round(current_price * 1.03, 2),
+                expected_gain_pct=3.0,
+                confidence_score=85,
+                trend_type="short_term",
+                source_model="TA-Strategy",
+                is_active=True,
+                is_public=True,
+                forecast_horizon="1d",
+                created_at=datetime.utcnow(),
+            )
+            db.session.add(pred)
+            created.append(data["symbol"])
+        db.session.commit()
+        logger.info(f"[TA-BULK] Otomatik tahminler üretildi: {created}")
+        return created
+    except Exception as e:  # pragma: no cover - just log errors
+        logger.error(f"[TA-BULK] Tahmin üretim hatası: {e}")
+        return []

--- a/tests/test_bulk_prediction.py
+++ b/tests/test_bulk_prediction.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend import create_app, db
+from backend.db.models import PredictionOpportunity
+from backend.tasks import bulk_prediction
+
+
+def test_generate_predictions_for_all_coins(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    app = create_app()
+    with app.app_context():
+        monkeypatch.setattr(
+            bulk_prediction.cg,
+            "get_coins_markets",
+            lambda vs_currency="usd", per_page=5, page=1: [
+                {"id": "bitcoin"},
+                {"id": "ethereum"},
+            ],
+        )
+        monkeypatch.setattr(
+            bulk_prediction,
+            "generate_ta_based_recommendation",
+            lambda symbol: {"symbol": symbol.upper()},
+        )
+        monkeypatch.setattr(bulk_prediction, "fetch_current_price", lambda symbol: 100.0)
+
+        created = bulk_prediction.generate_predictions_for_all_coins(limit=2)
+        assert set(created) == {"BITCOIN", "ETHEREUM"}
+        assert PredictionOpportunity.query.count() == 2


### PR DESCRIPTION
## Summary
- add helper to create TA-based predictions for multiple coins
- schedule bulk prediction task
- test bulk prediction generation

## Testing
- `pytest tests/test_bulk_prediction.py::test_generate_predictions_for_all_coins -q`
- `pytest -q` *(fails: check_and_downgrade_subscriptions, forecast API, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686ac92b81fc832f88c73fe0417088af