### PR TITLE
Add TA-Strategy filter and admin tab

### DIFF
--- a/backend/api/admin/predictions.py
+++ b/backend/api/admin/predictions.py
@@ -25,6 +25,7 @@ def list_predictions():
         order = request.args.get("order", "desc")
         symbol = request.args.get("symbol")
         is_successful = request.args.get("was_successful")
+        source_model = request.args.get("source_model")
 
         query = PredictionOpportunity.query
 
@@ -33,6 +34,8 @@ def list_predictions():
         if is_successful in ["true", "false"]:
             success_val = is_successful == "true"
             query = query.filter(PredictionOpportunity.was_successful == success_val)
+        if source_model:
+            query = query.filter(PredictionOpportunity.source_model == source_model)
 
         if order == "desc":
             query = query.order_by(getattr(PredictionOpportunity, sort_by).desc())

--- a/frontend/ytdcrypto-admin-dashboard
+++ b/frontend/ytdcrypto-admin-dashboard
@@ -147,6 +147,10 @@
                     <i data-lucide="bell-ring" class="w-5 h-5 mr-3"></i>
                     Bildirim Mekanizması
                 </a>
+                <a href="#" class="nav-link flex items-center p-3 rounded-lg hover:bg-slate-800 transition-colors" data-section="auto-ta">
+                    <i data-lucide="cpu" class="w-5 h-5 mr-3"></i>
+                    🧠 Otomatik Teknik Tahminler
+                </a>
                  <a href="#" class="nav-link flex items-center p-3 rounded-lg hover:bg-slate-800 transition-colors" data-section="guvenlik-yonetimi">
                     <i data-lucide="shield" class="w-5 h-5 mr-3"></i>
                     Güvenlik Yönetimi
@@ -436,7 +440,29 @@
                             <input type="checkbox" id="task-failures" class="rounded text-indigo-600 focus:ring-indigo-500">
                             <label for="task-failures" class="text-slate-300">Celery Görev Başarısızlıklarında Bildir</label>
                         </div>
-                        <button class="mt-4 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded-md">Ayarları Kaydet</button>
+                    <button class="mt-4 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded-md">Ayarları Kaydet</button>
+                </div>
+                </section>
+                <section id="auto-ta" class="content-section hidden">
+                    <h2 class="text-2xl font-bold mb-6 text-white">Otomatik Teknik Tahminler (TA-Strategy)</h2>
+                    <div class="bg-slate-800 p-6 rounded-lg border border-slate-700">
+                        <div class="overflow-x-auto">
+                            <table class="w-full text-left">
+                                <thead class="border-b border-slate-700">
+                                    <tr>
+                                        <th class="p-3">Sembol</th>
+                                        <th class="p-3">Hedef</th>
+                                        <th class="p-3">Getiri %</th>
+                                        <th class="p-3">Güven</th>
+                                        <th class="p-3">Oluşturulma</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="ta-table-body">
+                                    <tr class="border-b border-slate-800 hover:bg-slate-700"><td class="p-3" colspan="5">Tahmin bulunamadı.</td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <button id="load-ta-btn" class="mt-4 bg-slate-700 hover:bg-slate-600 text-white font-semibold py-2 px-4 rounded-md">Yükle</button>
                     </div>
                 </section>
                 <section id="guvenlik-yonetimi" class="content-section hidden">
@@ -529,6 +555,11 @@
             const ADMIN_API_KEY = "your_admin_secret_key"; // .env'deki ADMIN_ACCESS_KEY ile aynı olmalı
             const BACKEND_BASE_URL = 'http://localhost:5000';
             const SECURITY_ALARMS_API_URL = `${BACKEND_BASE_URL}/api/admin/security_alarms`;
+            const TA_PREDICTIONS_API_URL = `${BACKEND_BASE_URL}/api/admin/predictions?source_model=TA-Strategy`;
+
+            const taTableBody = document.getElementById('ta-table-body');
+            const loadTaButton = document.getElementById('load-ta-btn');
+            let taPage = 1;
 
             // Sidebar navigation logic
             navLinks.forEach(link => {
@@ -557,6 +588,11 @@
                         alarmOffset = 0; // Her sekme değişiminde sıfırla
                         securityAlarmsTableBody.innerHTML = ''; // Tabloyu temizle
                         fetchSecurityAlarms();
+                    }
+                    if (sectionId === 'auto-ta') {
+                        taPage = 1;
+                        taTableBody.innerHTML = '';
+                        fetchTaPredictions();
                     }
                      // Kullanıcı Yönetimi sekmesine tıklandığında kullanıcıları yükle
                     if (sectionId === 'kullanici-yonetimi') {
@@ -788,6 +824,49 @@
             }
 
             loadMoreUsersButton.addEventListener('click', fetchUsers);
+
+            async function fetchTaPredictions() {
+                try {
+                    const response = await fetch(`${TA_PREDICTIONS_API_URL}&page=${taPage}`, {
+                        headers: { 'X-ADMIN-API-KEY': ADMIN_API_KEY }
+                    });
+                    if (!response.ok) {
+                        const errorData = await response.json().catch(() => ({error: 'Yanıt JSON değil.'}));
+                        throw new Error(errorData.error || `HTTP Error: ${response.status}`);
+                    }
+                    const data = await response.json();
+
+                    if (taPage === 1) taTableBody.innerHTML = '';
+                    if (data.items && data.items.length) {
+                        data.items.forEach(p => {
+                            const row = document.createElement('tr');
+                            row.className = 'border-b border-slate-800 hover:bg-slate-700';
+                            row.innerHTML = `
+                                <td class="p-3">${p.symbol}</td>
+                                <td class="p-3">${p.target_price}</td>
+                                <td class="p-3">${p.expected_gain_pct}</td>
+                                <td class="p-3">${p.confidence_score}</td>
+                                <td class="p-3">${new Date(p.created_at).toLocaleDateString('tr-TR')}</td>
+                            `;
+                            taTableBody.appendChild(row);
+                        });
+                        taPage += 1;
+                        loadTaButton.disabled = data.items.length < data.per_page;
+                        lucide.createIcons();
+                    } else if (taPage === 1) {
+                        taTableBody.innerHTML = '<tr class="border-b border-slate-800 hover:bg-slate-700"><td class="p-3" colspan="5">Tahmin bulunamadı.</td></tr>';
+                        loadTaButton.disabled = true;
+                    } else {
+                        loadTaButton.disabled = true;
+                    }
+                } catch (error) {
+                    console.error('TA-Strategy tahminleri çekilirken hata:', error);
+                    taTableBody.innerHTML = `<tr class="border-b border-slate-800"><td class="p-3 text-red-400" colspan="5">Hata: ${error.message}</td></tr>`;
+                    loadTaButton.disabled = true;
+                }
+            }
+
+            loadTaButton.addEventListener('click', fetchTaPredictions);
 
             // Abonelik Kodu Üretme İşlevi
             generatePromoButton.addEventListener('click', async () => {

--- a/tests/test_predictions_api.py
+++ b/tests/test_predictions_api.py
@@ -89,3 +89,36 @@ def test_update_and_delete_prediction(monkeypatch):
 
     resp = client.delete(f"/api/admin/predictions/{pid}")
     assert resp.status_code == 200
+
+
+def test_filter_predictions_by_source_model(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setattr("backend.Config.SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
+    monkeypatch.setattr(
+        "backend.Config.SQLALCHEMY_ENGINE_OPTIONS",
+        {"poolclass": StaticPool, "connect_args": {"check_same_thread": False}},
+        raising=False,
+    )
+    import types, sys
+    sys.modules.setdefault("backend.core.routes", types.ModuleType("routes"))
+    services_stub = types.ModuleType("services")
+    services_stub.YTDCryptoSystem = object
+    sys.modules["backend.core.services"] = services_stub
+    monkeypatch.setattr(flask_jwt_extended, "jwt_required", lambda *a, **k: (lambda f: f))
+    monkeypatch.setattr(flask_jwt_extended, "fresh_jwt_required", lambda *a, **k: (lambda f: f), raising=False)
+    monkeypatch.setattr("backend.auth.middlewares.admin_required", lambda: (lambda f: f))
+    monkeypatch.setattr("backend.auth.jwt_utils.require_csrf", lambda f: f)
+    app = create_app()
+    client = app.test_client()
+
+    with app.app_context():
+        p1 = PredictionOpportunity(symbol="BTC", current_price=30000, target_price=35000, expected_gain_pct=10, source_model="TA-Strategy")
+        p2 = PredictionOpportunity(symbol="ETH", current_price=2000, target_price=2500, expected_gain_pct=5, source_model="Other")
+        db.session.add_all([p1, p2])
+        db.session.commit()
+
+    resp = client.get("/api/admin/predictions?source_model=TA-Strategy")
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data["total"] == 1
+    assert data["items"][0]["source_model"] == "TA-Strategy"


### PR DESCRIPTION
## Summary
- support `source_model` filter for admin predictions API
- extend admin dashboard with new "Otomatik Teknik Tahminler" tab
- fetch TA-Strategy predictions in admin UI
- test API filtering logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686acd083750832f8ad959301acd0b2d