### PR TITLE
Add advanced decision rule logic

### DIFF
--- a/backend/engine/rules.py
+++ b/backend/engine/rules.py
@@ -1,0 +1,30 @@
+def advanced_decision_logic(indicators: dict) -> dict:
+    score = 0
+    if indicators.get("rsi", 50) < 30:
+        score += 2
+    elif indicators.get("rsi", 50) > 70:
+        score -= 2
+
+    if indicators.get("macd", 0) > indicators.get("macd_signal", 0):
+        score += 2
+    else:
+        score -= 1
+
+    if indicators.get("price") is not None and indicators.get("sma_10") is not None:
+        if indicators["price"] > indicators["sma_10"]:
+            score += 1
+
+    if indicators.get("prev_predictions_success_rate", 0) > 0.7:
+        score += 1
+
+    signal = "buy" if score >= 3 else "hold" if score >= 1 else "avoid"
+    confidence = min(0.95, 0.6 + 0.1 * score)
+
+    return {"signal": signal, "confidence": round(confidence, 2)}
+
+from .decision_maker import build_prediction
+
+
+def make_reliable_prediction(df, indicators):
+    model_result = advanced_decision_logic(indicators)
+    return build_prediction(df, model_result)

--- a/tests/test_advanced_logic.py
+++ b/tests/test_advanced_logic.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from backend.engine.rules import advanced_decision_logic, make_reliable_prediction
+
+
+def test_buy_signal():
+    inds = {
+        "rsi": 25,
+        "macd": 1.2,
+        "macd_signal": 0.5,
+        "price": 10,
+        "sma_10": 9,
+        "prev_predictions_success_rate": 0.8,
+    }
+    result = advanced_decision_logic(inds)
+    assert result["signal"] == "buy"
+    assert result["confidence"] >= 0.6
+
+
+def test_avoid_signal():
+    inds = {
+        "rsi": 75,
+        "macd": 0.5,
+        "macd_signal": 1.0,
+        "price": 10,
+        "sma_10": 11,
+        "prev_predictions_success_rate": 0.5,
+    }
+    result = advanced_decision_logic(inds)
+    assert result["signal"] == "avoid"
+
+
+def test_hold_signal_and_build_prediction():
+    df = pd.DataFrame([{"price": 10, "symbol": "BTC"}])
+    inds = {
+        "rsi": 50,
+        "macd": 0.5,
+        "macd_signal": 0.5,
+        "price": 10,
+        "sma_10": 10,
+        "prev_predictions_success_rate": 0.55,
+    }
+    pred = make_reliable_prediction(df, inds)
+    assert pred is None


### PR DESCRIPTION
## Summary
- create `advanced_decision_logic` and `make_reliable_prediction`
- test new rule-based functions

## Testing
- `pytest tests/test_advanced_logic.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: pycoingecko etc)*

------
https://chatgpt.com/codex/tasks/task_e_686ad60e40b8832f939a18a29e02cfb0