### PR TITLE
Add strategic decision engine

### DIFF
--- a/backend/engine/__init__.py
+++ b/backend/engine/__init__.py
@@ -1,1 +1,2 @@
 # Prediction engine package
+from .strategic_decision_engine import advanced_decision_logic

--- a/backend/engine/strategic_decision_engine.py
+++ b/backend/engine/strategic_decision_engine.py
@@ -1,0 +1,30 @@
+def advanced_decision_logic(indicators: dict) -> dict:
+    score = 0
+    if indicators.get("rsi") is not None:
+        if indicators["rsi"] < 30:
+            score += 2
+        elif indicators["rsi"] > 70:
+            score -= 2
+
+    if indicators.get("macd") is not None and indicators.get("macd_signal") is not None:
+        if indicators["macd"] > indicators["macd_signal"]:
+            score += 2
+        else:
+            score -= 1
+
+    if indicators.get("price") and indicators.get("sma_10") and indicators["price"] > indicators["sma_10"]:
+        score += 1
+
+    if indicators.get("prev_predictions_success_rate", 0) > 0.7:
+        score += 1
+
+    if score >= 3:
+        signal = "buy"
+    elif score >= 1:
+        signal = "hold"
+    else:
+        signal = "avoid"
+
+    confidence = min(0.95, 0.6 + 0.1 * score)
+    return {"signal": signal, "confidence": round(confidence, 2)}
+


### PR DESCRIPTION
## Summary
- add advanced decision logic module
- expose function in engine package

## Testing
- `pytest -q` *(fails: assert <SubscriptionPlan.PREMIUM: 3> == <SubscriptionPlan.BASIC: 1> etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686ad6a4d830832fb1cee95e8d067fd4