### PR TITLE
Update TA recommender to use advanced engine

### DIFF
--- a/backend/tasks/strategic_recommender.py
+++ b/backend/tasks/strategic_recommender.py
@@ -1,8 +1,10 @@
 from backend.db.models import TechnicalIndicator
 from sqlalchemy import desc
+from backend.engine.strategic_decision_engine import advanced_decision_logic
 
 
 def generate_ta_based_recommendation(symbol="bitcoin"):
+    """Create a recommendation using the advanced decision engine."""
     indicator = (
         TechnicalIndicator.query.filter_by(symbol=symbol.upper())
         .order_by(desc(TechnicalIndicator.created_at))
@@ -11,24 +13,24 @@ def generate_ta_based_recommendation(symbol="bitcoin"):
     if not indicator:
         return None
 
-    recommendation = []
-    if indicator.rsi is not None:
-        if indicator.rsi < 30:
-            recommendation.append("RSI çok düşük → Aşırı satım bölgesi")
-        elif indicator.rsi > 70:
-            recommendation.append("RSI çok yüksek → Aşırı alım bölgesi")
+    indicators = {
+        "rsi": indicator.rsi,
+        "macd": indicator.macd,
+        "macd_signal": indicator.signal,
+        "price": None,  # Can be filled with live price data
+        "sma_10": None,
+        "prev_predictions_success_rate": 0.75,
+    }
 
-    if indicator.macd is not None and indicator.signal is not None:
-        if indicator.macd > indicator.signal:
-            recommendation.append("MACD > Signal → Al sinyali")
-        else:
-            recommendation.append("MACD < Signal → Sat sinyali")
+    decision = advanced_decision_logic(indicators)
+    if decision["signal"] == "avoid":
+        return None
 
     return {
         "symbol": symbol.upper(),
-        "rsi": round(indicator.rsi, 2) if indicator.rsi is not None else None,
-        "macd": round(indicator.macd, 2) if indicator.macd is not None else None,
-        "signal": round(indicator.signal, 2) if indicator.signal is not None else None,
+        "rsi": indicator.rsi,
+        "macd": indicator.macd,
+        "signal": indicator.signal,
+        "insight": decision,
         "created_at": indicator.created_at.isoformat(),
-        "insight": recommendation,
     }

--- a/tests/test_ta_insight.py
+++ b/tests/test_ta_insight.py
@@ -17,4 +17,5 @@ def test_generate_ta_based_recommendation(monkeypatch):
         db.session.commit()
         data = generate_ta_based_recommendation("BTC")
         assert data["symbol"] == "BTC"
-        assert any("Aşırı satım" in msg for msg in data["insight"])
+        assert data["insight"]["signal"] == "buy"
+        assert data["insight"]["confidence"] > 0.5


### PR DESCRIPTION
## Summary
- use `advanced_decision_logic` inside the TA recommender
- update TA insight test for the new return format

## Testing
- `pytest tests/test_ta_insight.py::test_generate_ta_based_recommendation -q`
- `pytest -q` *(fails: downgrade task, forecast api, predictions api, promo codes, rbac, sessions, upgrade api)*

------
https://chatgpt.com/codex/tasks/task_e_686adbf051e8832faeab4f0fba42bc21