### PR TITLE
Add prediction creation helper function

### DIFF
--- a/backend/tasks/strategic_recommender.py
+++ b/backend/tasks/strategic_recommender.py
@@ -1,6 +1,9 @@
-from backend.db.models import TechnicalIndicator
+from backend.db.models import TechnicalIndicator, PredictionOpportunity
 from sqlalchemy import desc
 from backend.engine.strategic_decision_engine import advanced_decision_logic
+from backend.utils.price_fetcher import fetch_current_price
+from backend.db import db
+from datetime import datetime, timedelta
 
 
 def generate_ta_based_recommendation(symbol="bitcoin"):
@@ -34,3 +37,31 @@ def generate_ta_based_recommendation(symbol="bitcoin"):
         "insight": decision,
         "created_at": indicator.created_at.isoformat(),
     }
+
+
+def create_prediction_from_decision(symbol: str, indicators: dict) -> dict | None:
+    """Verilen teknik göstergelere göre karar alır ve tahmin oluşturur."""
+    decision = advanced_decision_logic(indicators)
+    if decision["signal"] != "buy":
+        return None
+
+    price = fetch_current_price(symbol)
+    if not price:
+        return None
+
+    prediction = PredictionOpportunity(
+        symbol=symbol.upper(),
+        current_price=price,
+        target_price=round(price * 1.05, 2),
+        expected_gain_pct=5.0,
+        confidence_score=int(decision["confidence"] * 100),
+        trend_type="short_term",
+        source_model="StrategicDecisionEngine",
+        is_active=True,
+        is_public=True,
+        forecast_horizon="1d",
+        created_at=datetime.utcnow(),
+    )
+    db.session.add(prediction)
+    db.session.commit()
+    return prediction.to_dict()

--- a/tests/test_prediction_creation.py
+++ b/tests/test_prediction_creation.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend import create_app, db
+from backend.db.models import PredictionOpportunity
+from backend.tasks.strategic_recommender import create_prediction_from_decision
+
+
+def test_create_prediction_from_decision(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    app = create_app()
+    with app.app_context():
+        monkeypatch.setattr(
+            "backend.tasks.strategic_recommender.fetch_current_price", lambda symbol: 100.0
+        )
+        indicators = {
+            "rsi": 25,
+            "macd": 1.2,
+            "macd_signal": 0.8,
+            "price": 100,
+            "sma_10": 98,
+            "prev_predictions_success_rate": 0.75,
+        }
+        result = create_prediction_from_decision("bitcoin", indicators)
+        assert result["symbol"] == "BITCOIN"
+        assert PredictionOpportunity.query.count() == 1
+
+
+def test_create_prediction_from_decision_no_buy(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    app = create_app()
+    with app.app_context():
+        monkeypatch.setattr(
+            "backend.tasks.strategic_recommender.fetch_current_price", lambda symbol: 100.0
+        )
+        indicators = {
+            "rsi": 80,
+            "macd": 0.5,
+            "macd_signal": 1.0,
+            "price": 100,
+            "sma_10": 110,
+            "prev_predictions_success_rate": 0.5,
+        }
+        result = create_prediction_from_decision("bitcoin", indicators)
+        assert result is None
+        assert PredictionOpportunity.query.count() == 0
+


### PR DESCRIPTION
## Summary
- add `create_prediction_from_decision` helper to create PredictionOpportunity
- test creating predictions from engine decision

## Testing
- `pytest -q tests/test_prediction_creation.py::test_create_prediction_from_decision`
- `pytest -q` *(fails: assert <SubscriptionPlan.PREMIUM: 3> == <SubscriptionPlan.BASIC: 1> etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686add91ff1c832f96d172eff192e1c9