### PR TITLE
Add strategic predictions panel

### DIFF
--- a/frontend/prediction-display.html
+++ b/frontend/prediction-display.html
@@ -29,6 +29,11 @@
             </thead>
             <tbody id="pred-table"></tbody>
         </table>
+        <!-- Tahmin Kartları Bölümü -->
+        <div id="strategic-section" class="mt-6 space-y-4">
+            <h2 class="text-xl font-semibold">📊 Stratejik Tahminler</h2>
+            <div id="strategic-predictions" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
+        </div>
     </div>
     <script>
         async function loadPredictions(page = 1) {
@@ -93,9 +98,30 @@
                 `;
             }
         }
+        async function loadStrategicPredictions() {
+            const res = await fetch('/api/admin/predictions/public?page=1&per_page=10');
+            const data = await res.json();
+            const container = document.getElementById("strategic-predictions");
+            container.innerHTML = "";
+
+            for (const item of data.items) {
+                const card = document.createElement("div");
+                card.className = "bg-white rounded shadow p-4 border border-gray-300";
+
+                card.innerHTML = `
+            <h3 class="text-lg font-bold text-indigo-700">${item.symbol}</h3>
+            <p><strong>Beklenen Getiri:</strong> %${item.expected_gain_pct}</p>
+            <p><strong>Getiri Süresi:</strong> ${item.expected_gain_days}</p>
+            <p><strong>Güven:</strong> %${Math.round((item.confidence || 0) * 100)}</p>
+            <p class="text-sm text-gray-600 mt-2">${item.description}</p>
+        `;
+                container.appendChild(card);
+            }
+        }
         document.addEventListener('DOMContentLoaded', () => {
             loadTA();
             loadPredictions();
+            loadStrategicPredictions(); // 👈 ekledik
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add new strategic predictions panel to display strategic forecasts
- fetch strategic predictions and render as cards
- call `loadStrategicPredictions` on page load

## Testing
- `pytest -q` *(fails: AttributeError: 'Flask' object has no attribute 'ytd_system_instance', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686af4e2e95c832fb5523f704ca301e8