### PR TITLE
Add filter tabs for strategic predictions

### DIFF
--- a/frontend/prediction-display.html
+++ b/frontend/prediction-display.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8">
     <title>Tahmin Fırsatları</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        .tab-button {
+            padding: 0.5rem 0.75rem;
+            border-radius: 0.25rem;
+            border: 1px solid #d1d5db;
+            background-color: #e5e7eb;
+            color: #1f2937;
+        }
+        .tab-button.active {
+            background-color: #4f46e5;
+            color: #ffffff;
+        }
+    </style>
 </head>
 <body class="bg-gray-100 text-gray-900 p-6">
     <div class="max-w-6xl mx-auto">
@@ -32,6 +45,10 @@
         <!-- Tahmin Kartları Bölümü -->
         <div id="strategic-section" class="mt-6 space-y-4">
             <h2 class="text-xl font-semibold">📊 Stratejik Tahminler</h2>
+            <div class="flex space-x-2 mb-4">
+                <button class="tab-button active" onclick="setFilter('buy')">📈 Yükselenler</button>
+                <button class="tab-button" onclick="setFilter('hold')">🤝 Tutulması Önerilenler</button>
+            </div>
             <div id="strategic-predictions" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
         </div>
     </div>
@@ -98,6 +115,20 @@
                 `;
             }
         }
+
+        let currentSignalFilter = 'buy';
+
+        function setFilter(type) {
+            currentSignalFilter = type;
+            document.querySelectorAll('.tab-button').forEach(btn => btn.classList.remove('active'));
+            if (type === 'buy') {
+                document.querySelectorAll('.tab-button')[0].classList.add('active');
+            } else {
+                document.querySelectorAll('.tab-button')[1].classList.add('active');
+            }
+            loadStrategicPredictions();
+        }
+
         async function loadStrategicPredictions() {
             const res = await fetch('/api/admin/predictions/public?page=1&per_page=10');
             const data = await res.json();
@@ -105,17 +136,20 @@
             container.innerHTML = "";
 
             for (const item of data.items) {
-                const card = document.createElement("div");
-                card.className = "bg-white rounded shadow p-4 border border-gray-300";
+                if ((currentSignalFilter === 'buy' && item.expected_gain_pct >= 10) ||
+                    (currentSignalFilter === 'hold' && item.expected_gain_pct < 10)) {
+                    const card = document.createElement("div");
+                    card.className = "bg-white rounded shadow p-4 border border-gray-300";
 
-                card.innerHTML = `
-            <h3 class="text-lg font-bold text-indigo-700">${item.symbol}</h3>
-            <p><strong>Beklenen Getiri:</strong> %${item.expected_gain_pct}</p>
-            <p><strong>Getiri Süresi:</strong> ${item.expected_gain_days}</p>
-            <p><strong>Güven:</strong> %${Math.round((item.confidence || 0) * 100)}</p>
-            <p class="text-sm text-gray-600 mt-2">${item.description}</p>
-        `;
-                container.appendChild(card);
+                    card.innerHTML = `
+                <h3 class="text-lg font-bold text-indigo-700">${item.symbol}</h3>
+                <p><strong>Beklenen Getiri:</strong> %${item.expected_gain_pct}</p>
+                <p><strong>Getiri Süresi:</strong> ${item.expected_gain_days}</p>
+                <p><strong>Güven:</strong> %${Math.round((item.confidence || 0) * 100)}</p>
+                <p class="text-sm text-gray-600 mt-2">${item.description}</p>
+            `;
+                    container.appendChild(card);
+                }
             }
         }
         document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- introduce styles for tab buttons
- add buy/hold filter tabs in strategic predictions section
- implement filter logic in JS

## Testing
- `pytest -q` *(fails: AttributeError: 'Flask' object has no attribute 'ytd_system_instance', plus other assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c3d856e04832f82c1a642e9ea149a