### PR TITLE
Add admin prediction filtering page

### DIFF
--- a/backend/api/admin/predictions.py
+++ b/backend/api/admin/predictions.py
@@ -64,6 +64,8 @@ def public_predictions():
         per_page = int(request.args.get("per_page", 20))
         trend_type = request.args.get("trend_type")
         min_confidence = request.args.get("min_confidence", type=float)
+        symbol = request.args.get("symbol")
+        duration_range = request.args.get("duration_range")
 
         q = PredictionOpportunity.query.filter_by(is_active=True, is_public=True)
 
@@ -71,6 +73,14 @@ def public_predictions():
             q = q.filter(PredictionOpportunity.trend_type == trend_type)
         if min_confidence is not None:
             q = q.filter(PredictionOpportunity.confidence_score >= min_confidence)
+        if symbol:
+            q = q.filter(PredictionOpportunity.symbol.ilike(f"%{symbol}%"))
+        if duration_range:
+            try:
+                min_days, max_days = duration_range.split("-")
+                q = q.filter(PredictionOpportunity.expected_gain_days.ilike(f"{min_days}-%"))
+            except Exception:
+                pass
 
         total = q.count()
         predictions = (

--- a/frontend/admin/predictions.html
+++ b/frontend/admin/predictions.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <title>Tahminler | Admin Panel</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-900 p-6">
+  <div class="max-w-6xl mx-auto">
+    <h1 class="text-2xl font-bold mb-4">Tahmin Filtreleme</h1>
+    <div class="flex flex-wrap gap-2 mb-4">
+      <input id="filter-symbol" type="text" placeholder="Sembol" class="border px-3 py-2 rounded">
+      <select id="filter-trend" class="border px-3 py-2 rounded">
+        <option value="">Trend tipi</option>
+        <option value="short_term">short_term</option>
+        <option value="long_term">long_term</option>
+      </select>
+      <input id="filter-confidence" type="number" step="0.1" placeholder="Min güven" class="border px-3 py-2 rounded">
+      <input id="filter-duration" type="text" placeholder="Süre aralığı (örn. 30-60)" class="border px-3 py-2 rounded">
+      <button onclick="loadFilteredPredictions()" class="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700">Filtrele</button>
+    </div>
+    <div id="strategic-predictions" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
+  </div>
+<script>
+async function loadFilteredPredictions(page = 1) {
+    const symbolInput = document.getElementById("filter-symbol").value.trim().toUpperCase();
+    const trend = document.getElementById("filter-trend").value;
+    const conf = document.getElementById("filter-confidence").value;
+    const duration = document.getElementById("filter-duration").value;
+
+    const params = new URLSearchParams({ page, per_page: 20 });
+
+    if (symbolInput) {
+        params.append("symbol", symbolInput);
+    }
+    if (trend) {
+        params.append("trend_type", trend);
+    }
+    if (conf) {
+        params.append("min_confidence", conf);
+    }
+    if (duration) {
+        params.append("duration_range", duration);
+    }
+
+    const res = await fetch('/api/admin/predictions/public?' + params.toString());
+    const data = await res.json();
+    const container = document.getElementById("strategic-predictions");
+    container.innerHTML = "";
+
+    for (const item of (data.items || [])) {
+        const card = document.createElement("div");
+        card.className = "bg-white rounded shadow p-4 border border-gray-300";
+        card.innerHTML = `
+            <h3 class="text-lg font-bold text-indigo-700">${item.symbol}</h3>
+            <p><strong>Beklenen Getiri:</strong> %${item.expected_gain_pct}</p>
+            <p><strong>Getiri Süresi:</strong> ${item.expected_gain_days}</p>
+            <p><strong>Güven:</strong> %${Math.round((item.confidence || 0) * 100)}</p>
+            <p class="text-sm text-gray-600 mt-2">${item.description}</p>
+        `;
+        container.appendChild(card);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadFilteredPredictions();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add symbol and duration filtering to public predictions API
- create a new `frontend/admin/predictions.html` page for filtering predictions

## Testing
- `pip install -r backend/requirements.txt`
- `pip install pandas pandas-ta feedparser pycoingecko`
- `pytest -q` *(fails: AttributeError: 'Flask' object has no attribute 'ytd_system_instance', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686c44f24bc0832f809eeb5e53c9d851