### PR TITLE
Add Plan management endpoints and frontend

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -177,6 +177,7 @@ def create_app():
     from backend.auth.routes import auth_bp
     from backend.api.routes import api_bp
     from backend.admin_panel.routes import admin_bp
+    from backend.api.plan_routes import plan_bp
     from backend.api.admin.usage_limits import admin_usage_bp
     from backend.api.admin.promo_codes import admin_promo_bp
     from backend.api.admin.promo_stats import stats_bp
@@ -191,6 +192,7 @@ def create_app():
 
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
     app.register_blueprint(api_bp, url_prefix='/api')
+    app.register_blueprint(plan_bp, url_prefix='/api')
     app.register_blueprint(admin_bp, url_prefix='/api/admin')
     app.register_blueprint(admin_usage_bp)
     app.register_blueprint(admin_promo_bp)

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -10,3 +10,4 @@ api_bp = Blueprint('api', __name__)
 # ana uygulama tarafından tanınabilsinler.
 # Bu satırın çalışması için aynı dizinde route'ları tanımladığınız bir dosya olmalı.
 from backend.api import routes
+from backend.api import plan_routes

--- a/backend/api/plan_routes.py
+++ b/backend/api/plan_routes.py
@@ -1,0 +1,40 @@
+from flask import Blueprint, request, jsonify
+from backend.models.plan import Plan
+from backend.db import db
+
+plan_bp = Blueprint("plan_bp", __name__)
+
+@plan_bp.route("/plans", methods=["GET"])
+def get_plans():
+    plans = Plan.query.all()
+    return jsonify([p.to_dict() for p in plans])
+
+@plan_bp.route("/plans", methods=["POST"])
+def create_plan():
+    data = request.get_json()
+    new_plan = Plan(
+        name=data["name"],
+        price=data["price"],
+        features=data.get("features", ""),
+    )
+    db.session.add(new_plan)
+    db.session.commit()
+    return jsonify(new_plan.to_dict()), 201
+
+@plan_bp.route("/plans/<int:plan_id>", methods=["PUT"])
+def update_plan(plan_id):
+    plan = Plan.query.get_or_404(plan_id)
+    data = request.get_json()
+    plan.name = data.get("name", plan.name)
+    plan.price = data.get("price", plan.price)
+    plan.features = data.get("features", plan.features)
+    plan.is_active = data.get("is_active", plan.is_active)
+    db.session.commit()
+    return jsonify(plan.to_dict())
+
+@plan_bp.route("/plans/<int:plan_id>", methods=["DELETE"])
+def delete_plan(plan_id):
+    plan = Plan.query.get_or_404(plan_id)
+    db.session.delete(plan)
+    db.session.commit()
+    return jsonify({"message": "Plan silindi"})

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,3 @@
+from .plan import Plan
+
+__all__ = ["Plan"]

--- a/backend/models/plan.py
+++ b/backend/models/plan.py
@@ -1,0 +1,18 @@
+from backend.db import db
+
+class Plan(db.Model):
+    __tablename__ = 'plans'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), nullable=False, unique=True)
+    price = db.Column(db.Float, nullable=False)
+    features = db.Column(db.Text, nullable=True)
+    is_active = db.Column(db.Boolean, default=True)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "price": self.price,
+            "features": self.features,
+            "is_active": self.is_active,
+        }

--- a/frontend/admin/plan_management.html
+++ b/frontend/admin/plan_management.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <title>Plan Yönetimi</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-900">
+<div class="p-4">
+  <h2 class="text-2xl font-bold mb-4">Plan Yönetimi</h2>
+  <table class="w-full text-left border">
+    <thead>
+      <tr class="bg-gray-200">
+        <th class="p-2">ID</th>
+        <th class="p-2">İsim</th>
+        <th class="p-2">Fiyat</th>
+        <th class="p-2">Aktif mi?</th>
+        <th class="p-2">İşlemler</th>
+      </tr>
+    </thead>
+    <tbody id="plan-table-body"></tbody>
+  </table>
+
+  <div class="mt-6">
+    <input id="plan-name" placeholder="Plan Adı" class="border p-2 mr-2" />
+    <input id="plan-price" placeholder="Fiyat" type="number" class="border p-2 mr-2" />
+    <button onclick="createPlan()" class="bg-green-500 text-white px-4 py-2">Plan Ekle</button>
+  </div>
+</div>
+<script>
+async function fetchPlans() {
+  const res = await fetch("/api/plans");
+  const plans = await res.json();
+  const tbody = document.getElementById("plan-table-body");
+  tbody.innerHTML = "";
+  plans.forEach(p => {
+    tbody.innerHTML += `
+      <tr>
+        <td class="p-2">${p.id}</td>
+        <td class="p-2">${p.name}</td>
+        <td class="p-2">${p.price}</td>
+        <td class="p-2">${p.is_active ? "✅" : "❌"}</td>
+        <td class="p-2">
+          <button onclick="deletePlan(${p.id})" class="text-red-500">Sil</button>
+        </td>
+      </tr>
+    `;
+  });
+}
+
+async function createPlan() {
+  const name = document.getElementById("plan-name").value;
+  const price = parseFloat(document.getElementById("plan-price").value);
+  await fetch("/api/plans", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, price })
+  });
+  fetchPlans();
+}
+
+async function deletePlan(id) {
+  await fetch(`/api/plans/${id}`, { method: "DELETE" });
+  fetchPlans();
+}
+
+fetchPlans();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Plan SQLAlchemy model with basic fields
- expose CRUD endpoints for plans via new blueprint
- register the new blueprint in the Flask app
- include new admin page for plan management

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687023c7be34832f9432aa2c6c05a586