### PR TITLE
Implement admin auth and JSON features

### DIFF
--- a/backend/api/plan_routes.py
+++ b/backend/api/plan_routes.py
@@ -1,38 +1,45 @@
+import json
 from flask import Blueprint, request, jsonify
 from backend.models.plan import Plan
 from backend.db import db
+from backend.utils.decorators import admin_required
 
 plan_bp = Blueprint("plan_bp", __name__)
 
 @plan_bp.route("/plans", methods=["GET"])
+@admin_required
 def get_plans():
     plans = Plan.query.all()
     return jsonify([p.to_dict() for p in plans])
 
 @plan_bp.route("/plans", methods=["POST"])
+@admin_required
 def create_plan():
     data = request.get_json()
     new_plan = Plan(
         name=data["name"],
         price=data["price"],
-        features=data.get("features", ""),
+        features=json.dumps(data.get("features", {})),
     )
     db.session.add(new_plan)
     db.session.commit()
     return jsonify(new_plan.to_dict()), 201
 
 @plan_bp.route("/plans/<int:plan_id>", methods=["PUT"])
+@admin_required
 def update_plan(plan_id):
     plan = Plan.query.get_or_404(plan_id)
     data = request.get_json()
     plan.name = data.get("name", plan.name)
     plan.price = data.get("price", plan.price)
-    plan.features = data.get("features", plan.features)
+    if "features" in data:
+        plan.features = json.dumps(data.get("features"))
     plan.is_active = data.get("is_active", plan.is_active)
     db.session.commit()
     return jsonify(plan.to_dict())
 
 @plan_bp.route("/plans/<int:plan_id>", methods=["DELETE"])
+@admin_required
 def delete_plan(plan_id):
     plan = Plan.query.get_or_404(plan_id)
     db.session.delete(plan)

--- a/backend/models/plan.py
+++ b/backend/models/plan.py
@@ -1,3 +1,4 @@
+import json
 from backend.db import db
 
 class Plan(db.Model):
@@ -13,6 +14,6 @@ class Plan(db.Model):
             "id": self.id,
             "name": self.name,
             "price": self.price,
-            "features": self.features,
+            "features": json.loads(self.features or "{}"),
             "is_active": self.is_active,
         }

--- a/backend/utils/decorators.py
+++ b/backend/utils/decorators.py
@@ -1,13 +1,31 @@
 # backend/utils/decorators.py
 
 from functools import wraps
-from flask import g, jsonify
+from flask import g, jsonify, request
 from loguru import logger
 from backend.db.models import User, SubscriptionPlan, UserRole
 
 def _error_response(message: str, status_code: int):
     """Hata yanıtları için merkezi bir yardımcı fonksiyon."""
     return jsonify({"error": message}), status_code
+
+
+def admin_required(f):
+    """Authorization header'ındaki API anahtarını kontrol eder."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = request.headers.get("Authorization")
+        if not token:
+            return jsonify({"error": "Token gerekli"}), 401
+        if token.startswith("Bearer "):
+            token = token.split(" ", 1)[1]
+        user = User.query.filter_by(api_key=token).first()
+        if not user or user.role not in [UserRole.ADMIN, UserRole.SYSTEM_ADMIN]:
+            return jsonify({"error": "Yetkisiz erişim"}), 403
+        return f(*args, **kwargs)
+
+    return decorated
 
 def require_role(required_role: UserRole):
     """

--- a/tests/test_plan_api.py
+++ b/tests/test_plan_api.py
@@ -1,0 +1,48 @@
+import json
+import os
+import sys
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from backend import create_app, db
+from backend.models.plan import Plan
+from backend.db.models import User, Role, UserRole
+
+
+def setup_app(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setattr("backend.Config.SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
+    monkeypatch.setattr(
+        "backend.Config.SQLALCHEMY_ENGINE_OPTIONS",
+        {"poolclass": StaticPool, "connect_args": {"check_same_thread": False}},
+        raising=False,
+    )
+    return create_app()
+
+
+def create_admin(app):
+    with app.app_context():
+        role = Role.query.filter_by(name="admin").first()
+        admin = User(username="admin", api_key="adminkey", role_id=role.id, role=UserRole.ADMIN)
+        admin.set_password("pass")
+        db.session.add(admin)
+        db.session.commit()
+
+
+def test_plan_features_and_auth(monkeypatch):
+    app = setup_app(monkeypatch)
+    client = app.test_client()
+
+    with app.app_context():
+        p = Plan(name="Test", price=1.0, features=json.dumps({"a": 1}))
+        db.session.add(p)
+        db.session.commit()
+
+    resp = client.get("/api/plans")
+    assert resp.status_code == 401
+
+    create_admin(app)
+    resp = client.get("/api/plans", headers={"Authorization": "adminkey"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data[0]["features"]["a"] == 1


### PR DESCRIPTION
## Summary
- require admin API key for plan endpoints
- represent plan features as JSON
- implement admin authentication decorator
- test plan authentication and features

## Testing
- `pytest tests/test_plan_api.py::test_plan_features_and_auth -q`
- `pytest -q` *(fails: test_downgrade_expired_subscription etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687028713e54832f902fcdb411c372c1