### PR TITLE
Add filtering options to admin user listing

### DIFF
--- a/backend/api/admin/users.py
+++ b/backend/api/admin/users.py
@@ -13,7 +13,20 @@ user_admin_bp = Blueprint("user_admin", __name__, url_prefix="/api/admin/users")
 @jwt_required()
 @admin_required()
 def list_users():
-    users = User.query.all()
+    email = request.args.get("email")
+    role = request.args.get("role")
+    plan = request.args.get("subscription_level")
+
+    query = User.query
+
+    if email:
+        query = query.filter(User.email.ilike(f"%{email}%"))
+    if role:
+        query = query.filter(User.role == role)
+    if plan:
+        query = query.filter(User.subscription_level == plan)
+
+    users = query.all()
     return jsonify([u.to_dict() for u in users])
 
 

--- a/frontend/admin/user_management.html
+++ b/frontend/admin/user_management.html
@@ -8,6 +8,22 @@
 <body class="bg-gray-100 text-gray-900 p-6">
   <div class="max-w-5xl mx-auto">
     <h1 class="text-2xl font-bold mb-4">Kullanıcı Yönetimi</h1>
+    <div class="flex gap-4 mb-4">
+      <input id="search-email" placeholder="E-posta ara..." class="p-2 border rounded w-1/3" />
+      <select id="search-role" class="p-2 border rounded">
+        <option value="">Tüm Roller</option>
+        <option value="user">user</option>
+        <option value="admin">admin</option>
+        <option value="superadmin">superadmin</option>
+      </select>
+      <select id="search-plan" class="p-2 border rounded">
+        <option value="">Tüm Planlar</option>
+        <option value="Free">Free</option>
+        <option value="Pro">Pro</option>
+        <option value="Premium">Premium</option>
+      </select>
+      <button onclick="loadUsers()" class="bg-blue-600 text-white px-4 py-2 rounded">Filtrele</button>
+    </div>
     <table class="w-full text-left border border-gray-300 rounded">
       <thead class="bg-gray-100">
         <tr>
@@ -28,9 +44,19 @@
     const JWT = sessionStorage.getItem('admin_jwt');
 
     async function loadUsers() {
-      const res = await fetch(API + '/', {
+      const email = document.getElementById('search-email').value;
+      const role = document.getElementById('search-role').value;
+      const plan = document.getElementById('search-plan').value;
+
+      const params = new URLSearchParams();
+      if (email) params.append('email', email);
+      if (role) params.append('role', role);
+      if (plan) params.append('subscription_level', plan);
+
+      const res = await fetch(API + '?' + params.toString(), {
         headers: { 'Authorization': 'Bearer ' + JWT }
       });
+
       const users = await res.json();
       const tbody = document.getElementById('user-table-body');
       tbody.innerHTML = '';


### PR DESCRIPTION
## Summary
- implement query param filters for email, role and plan in `/api/admin/users`
- add filter fields and update JS logic in admin user management interface

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68703368e6e4832fbeec8347770f5618