### PR TITLE
Add audit logging feature

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -183,6 +183,7 @@ def create_app():
     from backend.api.admin.promo_stats import stats_bp
     from backend.api.admin.predictions import predictions_bp
     from backend.api.admin.users import user_admin_bp
+    from backend.api.admin.audit import audit_bp
     from backend.api.ta_routes import bp as ta_bp
     from backend.api.public.technical import technical_bp
     from backend.api.public.subscriptions import subscriptions_bp
@@ -200,6 +201,7 @@ def create_app():
     app.register_blueprint(stats_bp)
     app.register_blueprint(predictions_bp)
     app.register_blueprint(user_admin_bp)
+    app.register_blueprint(audit_bp, url_prefix='/api')
     app.register_blueprint(ta_bp)
     app.register_blueprint(technical_bp)
     app.register_blueprint(subscriptions_bp)

--- a/backend/admin_panel/routes.py
+++ b/backend/admin_panel/routes.py
@@ -20,6 +20,8 @@ import uuid
 from datetime import datetime, timedelta
 from backend.utils.rbac import require_permission
 from backend.auth.middlewares import admin_required as _admin_required
+from flask_jwt_extended import get_jwt_identity
+from backend.utils.audit import log_action
 
 
 def admin_required(f):
@@ -84,6 +86,13 @@ def update_user_details(user_id):
 
         db.session.commit()
         logger.info(f"Kullanıcı {user.username} detayları güncellendi.")
+        admin_id = get_jwt_identity()
+        admin_user = User.query.get(admin_id) if admin_id else None
+        log_action(
+            admin_user,
+            action="plan_update",
+            details=f"Kullanıcı {user.username}, yeni plan: {user.subscription_level.value}",
+        )
         return jsonify({"message": "Kullanıcı başarıyla güncellendi.", "user": {
             "id": user.id,
             "username": user.username,

--- a/backend/api/admin/audit.py
+++ b/backend/api/admin/audit.py
@@ -1,0 +1,30 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
+from backend.auth.middlewares import admin_required
+from backend.db.models import AuditLog
+
+audit_bp = Blueprint("audit_bp", __name__)
+
+
+@audit_bp.route("/admin/audit-logs", methods=["GET"])
+@jwt_required()
+@admin_required()
+def get_logs():
+    limit = int(request.args.get("limit", 100))
+    logs = (
+        AuditLog.query.order_by(AuditLog.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+    return jsonify([
+        {
+            "id": l.id,
+            "user_id": l.user_id,
+            "username": l.username,
+            "action": l.action,
+            "ip_address": l.ip_address,
+            "details": l.details,
+            "created_at": l.created_at.isoformat(),
+        }
+        for l in logs
+    ])

--- a/backend/auth/routes.py
+++ b/backend/auth/routes.py
@@ -15,6 +15,7 @@ from loguru import logger
 from backend import limiter
 from backend.utils.token_helper import generate_reset_token, verify_reset_token
 from backend.utils.email import send_password_reset_email
+from backend.utils.audit import log_action
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from datetime import datetime, timedelta
 import uuid
@@ -120,6 +121,7 @@ def login_user():
         )
 
         logger.info(f"Kullanıcı girişi başarılı: {username}")
+        log_action(user, action="login")
         return response
 
     except Exception:
@@ -229,4 +231,5 @@ def reset_password():
     user.password_hash = generate_password_hash(new_password)
     reset_entry.is_used = True
     db.session.commit()
+    log_action(user, action="password_reset")
     return jsonify({"message": "Şifre başarıyla güncellendi."}), 200

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -546,3 +546,19 @@ class TechnicalIndicator(db.Model):
             "signal": self.signal,
             "created_at": self.created_at.isoformat(),
         }
+
+
+class AuditLog(db.Model):
+    """Stores user actions for auditing purposes."""
+
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    username = Column(String(128), nullable=True)
+    action = Column(String(128), nullable=False)
+    ip_address = Column(String(64), nullable=True)
+    details = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", backref="audit_logs", lazy=True)

--- a/backend/utils/audit.py
+++ b/backend/utils/audit.py
@@ -1,0 +1,16 @@
+from flask import request
+from backend.db import db
+from backend.db.models import AuditLog
+
+
+def log_action(user=None, action: str = "", details=None) -> None:
+    """Record an audit log entry for the given user action."""
+    log = AuditLog(
+        user_id=getattr(user, "id", None),
+        username=getattr(user, "email", None) or getattr(user, "username", None),
+        action=action,
+        ip_address=request.remote_addr if request else None,
+        details=details,
+    )
+    db.session.add(log)
+    db.session.commit()

--- a/frontend/admin/audit_logs.html
+++ b/frontend/admin/audit_logs.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <title>Audit Logları</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-900">
+  <div class="p-4">
+    <h2 class="text-xl font-bold mb-4">Kullanıcı Eylem Kayıtları (Audit Trail)</h2>
+    <table class="w-full border text-left">
+      <thead class="bg-gray-100">
+        <tr>
+          <th class="p-2">Tarih</th>
+          <th class="p-2">Kullanıcı</th>
+          <th class="p-2">Aksiyon</th>
+          <th class="p-2">Detay</th>
+          <th class="p-2">IP</th>
+        </tr>
+      </thead>
+      <tbody id="audit-table-body"></tbody>
+    </table>
+  </div>
+  <script>
+  async function loadAuditLogs() {
+    const res = await fetch("/api/admin/audit-logs?limit=100", {
+      headers: { Authorization: sessionStorage.getItem("token") }
+    });
+    const logs = await res.json();
+    const tbody = document.getElementById("audit-table-body");
+    tbody.innerHTML = "";
+    logs.forEach(l => {
+      tbody.innerHTML += `
+        <tr>
+          <td class="p-2">${new Date(l.created_at).toLocaleString()}</td>
+          <td class="p-2">${l.username || '-'}</td>
+          <td class="p-2">${l.action}</td>
+          <td class="p-2">${l.details || '-'}</td>
+          <td class="p-2">${l.ip_address || '-'}</td>
+        </tr>
+      `;
+    });
+  }
+  loadAuditLogs();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- track user actions with new `AuditLog` model
- helper `log_action` function for creating logs
- log important events such as login, password reset and plan updates
- expose `/api/admin/audit-logs` to list logs
- register audit blueprint and add simple frontend page

## Testing
- `pytest -q` *(fails: 15 failed, 18 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6870401a0b88832f9d94afa0e74918d1