### PR TITLE
Add automated plan expiry tasks

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -71,6 +71,16 @@ class Config:
             'schedule': timedelta(days=1),
             'options': {'queue': 'default'},
         },
+        'auto-downgrade-plans-everyday': {
+            'task': 'backend.tasks.plan_tasks.auto_downgrade_expired_plans',
+            'schedule': timedelta(days=1),
+            'options': {'queue': 'default'},
+        },
+        'auto-expire-boosts-everyday': {
+            'task': 'backend.tasks.plan_tasks.auto_expire_boosts',
+            'schedule': timedelta(days=1),
+            'options': {'queue': 'default'},
+        },
     }
     # CORS Origins ayarı .env dosyasından
     # supports_credentials=True ise origins ASLA '*' olmamalıdır.

--- a/backend/api/admin/plans.py
+++ b/backend/api/admin/plans.py
@@ -62,3 +62,17 @@ def change_user_plan(user_id):
         user.plan_expire_at = datetime.fromisoformat(data["expire_at"])
     db.session.commit()
     return jsonify(user.to_dict())
+
+
+@plan_admin_bp.route("/admin/plan-automation/run", methods=["POST"])
+@admin_required
+def manual_automation():
+    """Manually trigger plan automation tasks."""
+    from backend.tasks.plan_tasks import (
+        auto_downgrade_expired_plans,
+        auto_expire_boosts,
+    )
+
+    auto_downgrade_expired_plans.delay()
+    auto_expire_boosts.delay()
+    return jsonify({"ok": True})

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -123,6 +123,8 @@ class User(db.Model):
     plan_id = Column(Integer, ForeignKey("plans.id"), nullable=True)
     plan = db.relationship("Plan", backref="users")
     plan_expire_at = Column(DateTime, nullable=True)
+    boost_features = Column(Text, nullable=True)
+    boost_expire_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     is_active = Column(Boolean, default=True, nullable=False)
 
@@ -162,6 +164,8 @@ class User(db.Model):
             "is_active": self.is_active,
             "plan": self.plan.to_dict() if self.plan else None,
             "plan_expire_at": self.plan_expire_at.isoformat() if self.plan_expire_at else None,
+            "boost_features": self.boost_features,
+            "boost_expire_at": self.boost_expire_at.isoformat() if self.boost_expire_at else None,
         }
 
 

--- a/backend/tasks/__init__.py
+++ b/backend/tasks/__init__.py
@@ -35,6 +35,7 @@ def init_celery(app):
 def autodiscover_tasks():
     """Import Celery task modules."""
     import backend.tasks.celery_tasks  # noqa
+    import backend.tasks.plan_tasks  # noqa
 
 
 if os.getenv("FLASK_ENV") != "testing":

--- a/backend/tasks/plan_tasks.py
+++ b/backend/tasks/plan_tasks.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+import logging
+
+from flask import current_app
+
+from backend import celery_app, create_app, db
+from backend.db.models import User, UserRole
+from backend.models.plan import Plan
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task
+def auto_downgrade_expired_plans():
+    """Downgrade users whose plan has expired to the Free plan."""
+    logger.info("Checking for expired plans to downgrade")
+    ctx_app = current_app._get_current_object() if current_app else create_app()
+    with ctx_app.app_context():
+        now = datetime.utcnow()
+        free_plan = Plan.query.filter_by(name="Free").first()
+        if not free_plan:
+            logger.warning("Free plan not found; skipping downgrade")
+            return
+        users = (
+            User.query.filter(
+                User.plan_expire_at != None,
+                User.plan_expire_at < now,
+                User.plan_id != free_plan.id,
+                User.role == UserRole.USER,
+            ).all()
+        )
+        for u in users:
+            old_plan = u.plan_id
+            u.plan_id = free_plan.id
+            u.plan_expire_at = None
+            db.session.commit()
+            logger.info("Downgraded user %s from %s", u.username, old_plan)
+
+
+@celery_app.task
+def auto_expire_boosts():
+    """Clear boost features for users where the boost period expired."""
+    logger.info("Checking for expired boosts")
+    ctx_app = current_app._get_current_object() if current_app else create_app()
+    with ctx_app.app_context():
+        now = datetime.utcnow()
+        users = User.query.filter(
+            User.boost_expire_at != None,
+            User.boost_expire_at < now,
+        ).all()
+        for u in users:
+            u.boost_features = None
+            u.boost_expire_at = None
+            db.session.commit()
+            logger.info("Expired boost cleared for user %s", u.username)

--- a/migrations/versions/20250901_add_boost_fields.py
+++ b/migrations/versions/20250901_add_boost_fields.py
@@ -1,0 +1,24 @@
+"""Add boost columns to users
+
+Revision ID: 20250901_01
+Revises: 20250722_01
+Create Date: 2025-09-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20250901_01'
+down_revision = '20250722_01'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('boost_features', sa.Text(), nullable=True))
+    op.add_column('users', sa.Column('boost_expire_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('users', 'boost_expire_at')
+    op.drop_column('users', 'boost_features')

--- a/tests/test_plan_tasks.py
+++ b/tests/test_plan_tasks.py
@@ -1,0 +1,68 @@
+import os
+import sys
+from datetime import datetime, timedelta
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend import create_app, db
+from backend.db.models import User, Role, UserRole
+from backend.models.plan import Plan
+
+
+def setup_app(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    return create_app()
+
+
+def test_auto_downgrade_expired_plan(monkeypatch):
+    app = setup_app(monkeypatch)
+    with app.app_context():
+        role = Role.query.filter_by(name="user").first()
+        free = Plan(name="Free", price=0.0)
+        pro = Plan(name="Pro", price=10.0)
+        db.session.add_all([free, pro])
+        db.session.commit()
+        user = User(
+            username="planuser",
+            api_key="plankey",
+            role_id=role.id,
+            role=UserRole.USER,
+            plan_id=pro.id,
+            plan_expire_at=datetime.utcnow() - timedelta(days=1),
+        )
+        user.set_password("pass")
+        db.session.add(user)
+        db.session.commit()
+
+        from backend.tasks.plan_tasks import auto_downgrade_expired_plans
+
+        auto_downgrade_expired_plans.run()
+        db.session.expire_all()
+        updated = User.query.get(user.id)
+        assert updated.plan_id == free.id
+        assert updated.plan_expire_at is None
+
+
+def test_auto_expire_boost(monkeypatch):
+    app = setup_app(monkeypatch)
+    with app.app_context():
+        role = Role.query.filter_by(name="user").first()
+        user = User(
+            username="boostuser",
+            api_key="boostkey",
+            role_id=role.id,
+            role=UserRole.USER,
+            boost_features="{\"t\":1}",
+            boost_expire_at=datetime.utcnow() - timedelta(days=1),
+        )
+        user.set_password("pass")
+        db.session.add(user)
+        db.session.commit()
+
+        from backend.tasks.plan_tasks import auto_expire_boosts
+
+        auto_expire_boosts.run()
+        db.session.expire_all()
+        updated = User.query.get(user.id)
+        assert updated.boost_features is None
+        assert updated.boost_expire_at is None


### PR DESCRIPTION
## Summary
- add boost fields to `User` model
- implement automated plan and boost expiry tasks
- schedule these tasks with Celery beat
- allow manual trigger from admin API
- include Alembic migration
- cover new tasks with unit tests

## Testing
- `pytest tests/test_plan_tasks.py -q`
- `pytest -q` *(fails: AttributeError: 'Flask' object has no attribute 'ytd_system_instance' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6877fd51ec6c832f9b6070b2e3b3eb71