### PR TITLE
Integrate queued plan activation

### DIFF
--- a/backend/api/admin/plans.py
+++ b/backend/api/admin/plans.py
@@ -86,10 +86,12 @@ def manual_automation():
     from backend.tasks.plan_tasks import (
         auto_downgrade_expired_plans,
         auto_expire_boosts,
+        activate_pending_plans,
     )
 
     auto_downgrade_expired_plans.delay()
     auto_expire_boosts.delay()
+    activate_pending_plans.delay()
     return jsonify({"ok": True})
 
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,4 +1,13 @@
 from .plan import Plan
 from .promo_code import PromoCode
+from .pending_plan import PendingPlan
+from .plan_history import PlanHistory
+from .price_history import PriceHistory
 
-__all__ = ["Plan", "PromoCode"]
+__all__ = [
+    "Plan",
+    "PromoCode",
+    "PendingPlan",
+    "PlanHistory",
+    "PriceHistory",
+]

--- a/backend/models/pending_plan.py
+++ b/backend/models/pending_plan.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from backend.db import db
+
+class PendingPlan(db.Model):
+    __tablename__ = "pending_plans"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"))
+    plan_id = db.Column(db.Integer, db.ForeignKey("plans.id"))
+    start_at = db.Column(db.DateTime, nullable=False)
+    expire_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", backref="pending_plans", lazy=True)
+    plan = db.relationship("Plan", lazy=True)

--- a/backend/models/plan_history.py
+++ b/backend/models/plan_history.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from backend.db import db
+
+class PlanHistory(db.Model):
+    __tablename__ = "plan_history"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    plan_id = db.Column(db.Integer, db.ForeignKey("plans.id"), nullable=False)
+    device = db.Column(db.String(128))
+    ip = db.Column(db.String(64))
+    note = db.Column(db.String(256))
+    is_automatic = db.Column(db.Boolean, default=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", backref="plan_history", lazy=True)
+    plan = db.relationship("Plan", lazy=True)

--- a/backend/models/price_history.py
+++ b/backend/models/price_history.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from backend.db import db
+
+class PriceHistory(db.Model):
+    __tablename__ = "price_history"
+    id = db.Column(db.Integer, primary_key=True)
+    plan_id = db.Column(db.Integer, db.ForeignKey("plans.id"), nullable=False)
+    old_price = db.Column(db.Float)
+    new_price = db.Column(db.Float)
+    changed_at = db.Column(db.DateTime, default=datetime.utcnow)
+    changed_by = db.Column(db.String(64))
+
+    plan = db.relationship("Plan", lazy=True)

--- a/backend/utils/plan_limits.py
+++ b/backend/utils/plan_limits.py
@@ -27,3 +27,26 @@ def get_limit_status(user, limit_name, usage_value):
     elif ratio >= 0.8:
         return "limit_warning"
     return "ok"
+
+
+def get_user_effective_limits(user):
+    """Return merged feature limits for a user including plan, custom and boost."""
+    limits = user.plan.features_dict() if user.plan else {}
+    if getattr(user, "custom_features", None):
+        try:
+            limits.update(json.loads(user.custom_features or "{}"))
+        except Exception:
+            pass
+    if getattr(user, "boost_expire_at", None) and user.boost_expire_at > datetime.utcnow():
+        try:
+            limits.update(json.loads(user.boost_features or "{}"))
+        except Exception:
+            pass
+    return limits
+
+
+def give_user_boost(user, features, expire_at):
+    user.boost_features = json.dumps(features)
+    user.boost_expire_at = expire_at
+    from backend import db
+    db.session.commit()

--- a/tests/test_plan_limits.py
+++ b/tests/test_plan_limits.py
@@ -1,0 +1,28 @@
+import os, sys
+from datetime import datetime, timedelta
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from backend import create_app, db
+from backend.db.models import User, Role, UserRole
+from backend.models.plan import Plan
+from backend.utils.plan_limits import get_user_effective_limits, give_user_boost
+
+
+def setup_app(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    return create_app()
+
+
+def test_effective_limits_with_boost(monkeypatch):
+    app = setup_app(monkeypatch)
+    with app.app_context():
+        role = Role.query.filter_by(name="user").first()
+        p = Plan(name="LimitPlan", price=0.0, features="{\"max_prediction_per_day\": 5}")
+        db.session.add(p)
+        db.session.commit()
+        user = User(username="limituser", api_key="limitkey", role_id=role.id, role=UserRole.USER, plan_id=p.id)
+        user.set_password("pass")
+        db.session.add(user)
+        db.session.commit()
+        give_user_boost(user, {"max_prediction_per_day": 10}, datetime.utcnow() + timedelta(days=1))
+        limits = get_user_effective_limits(user)
+        assert limits["max_prediction_per_day"] == 10


### PR DESCRIPTION
## Summary
- add PendingPlan, PlanHistory, PriceHistory models
- schedule queued plan activation and log events
- expose new models in backend.models
- expand admin plan automation endpoint
- add helpers for merged limits and boosting
- test pending plan activation and limit merging

## Testing
- `pytest tests/test_plan_tasks.py::test_activate_pending_plan tests/test_plan_limits.py::test_effective_limits_with_boost -q`

------
https://chatgpt.com/codex/tasks/task_e_68780ba8db98832f83ed3cd28a911b0d