### PR TITLE
Add database backup endpoints

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -198,6 +198,7 @@ def create_app():
     from backend.api.admin.predictions import predictions_bp
     from backend.api.admin.users import user_admin_bp
     from backend.api.admin.audit import audit_bp
+    from backend.api.admin.backup import backup_bp
     from backend.api.ta_routes import bp as ta_bp
     from backend.api.public.technical import technical_bp
     from backend.api.public.subscriptions import subscriptions_bp
@@ -217,6 +218,7 @@ def create_app():
     app.register_blueprint(predictions_bp)
     app.register_blueprint(user_admin_bp)
     app.register_blueprint(audit_bp, url_prefix='/api')
+    app.register_blueprint(backup_bp)
     app.register_blueprint(ta_bp)
     app.register_blueprint(technical_bp)
     app.register_blueprint(subscriptions_bp)

--- a/backend/api/admin/backup.py
+++ b/backend/api/admin/backup.py
@@ -1,0 +1,106 @@
+from flask import Blueprint, send_file, request, jsonify, abort
+from flask_jwt_extended import jwt_required
+from backend.auth.middlewares import admin_required
+from backend.db import db
+from backend.db.models import DatabaseBackup, User
+from backend.utils.audit import log_action
+import os
+import subprocess
+import hashlib
+from datetime import datetime
+
+backup_bp = Blueprint("backup", __name__, url_prefix="/api/admin/backup")
+
+BACKUP_DIR = os.path.join(os.getcwd(), "backups")
+RETENTION = int(os.getenv("BACKUP_RETENTION", "5"))
+DB_FILE = os.getenv("DATABASE_FILE", "ytd_crypto.db")
+
+
+def ensure_backup_dir():
+    if not os.path.exists(BACKUP_DIR):
+        os.makedirs(BACKUP_DIR, exist_ok=True)
+
+
+@backup_bp.route("", methods=["POST"])
+@jwt_required()
+@admin_required()
+def create_backup():
+    ensure_backup_dir()
+    admin_id = request.headers.get("X-Admin-ID")
+    admin = User.query.get(admin_id) if admin_id else None
+
+    filename = f"backup_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}.db"
+    path = os.path.join(BACKUP_DIR, filename)
+
+    # only works for sqlite; in tests we assume sqlite
+    subprocess.run(["sqlite3", DB_FILE, f".backup {path}"], check=False)
+
+    with open(path, "rb") as f:
+        file_hash = hashlib.sha256(f.read()).hexdigest()
+
+    entry = DatabaseBackup(filename=filename, admin_id=admin.id if admin else None, file_hash=file_hash)
+    db.session.add(entry)
+    db.session.commit()
+    log_action(admin, "backup_created", filename)
+
+    # retention logic
+    backups = DatabaseBackup.query.order_by(DatabaseBackup.created_at.desc()).all()
+    if len(backups) > RETENTION:
+        for old in backups[RETENTION:]:
+            try:
+                os.remove(os.path.join(BACKUP_DIR, old.filename))
+            except FileNotFoundError:
+                pass
+            db.session.delete(old)
+        db.session.commit()
+
+    return jsonify({"ok": True, "id": entry.id, "filename": filename})
+
+
+@backup_bp.route("/list", methods=["GET"])
+@jwt_required()
+@admin_required()
+def list_backups():
+    backups = DatabaseBackup.query.order_by(DatabaseBackup.created_at.desc()).limit(20).all()
+    return jsonify([
+        {
+            "id": b.id,
+            "filename": b.filename,
+            "created_at": b.created_at.isoformat(),
+            "admin_id": b.admin_id,
+        }
+        for b in backups
+    ])
+
+
+@backup_bp.route("/download/<int:backup_id>", methods=["GET"])
+@jwt_required()
+@admin_required()
+def download_backup(backup_id):
+    backup = DatabaseBackup.query.get_or_404(backup_id)
+    path = os.path.join(BACKUP_DIR, backup.filename)
+    if not os.path.exists(path):
+        abort(404)
+    return send_file(path, as_attachment=True)
+
+
+@backup_bp.route("/restore", methods=["POST"])
+@jwt_required()
+@admin_required()
+def restore_backup():
+    data = request.get_json() or {}
+    backup_id = data.get("backup_id")
+    if not backup_id:
+        return jsonify({"error": "backup_id required"}), 400
+    backup = DatabaseBackup.query.get_or_404(backup_id)
+    path = os.path.join(BACKUP_DIR, backup.filename)
+    if not os.path.exists(path):
+        return jsonify({"error": "File not found"}), 404
+
+    admin_id = request.headers.get("X-Admin-ID")
+    admin = User.query.get(admin_id) if admin_id else None
+
+    subprocess.run(["cp", path, DB_FILE], check=False)
+    log_action(admin, "backup_restored", backup.filename)
+    return jsonify({"ok": True})
+

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -576,3 +576,18 @@ class AuditLog(db.Model):
     created_at = Column(DateTime, default=datetime.utcnow)
 
     user = db.relationship("User", backref="audit_logs", lazy=True)
+
+
+class DatabaseBackup(db.Model):
+    """Stores database backup metadata."""
+
+    __tablename__ = "database_backups"
+
+    id = Column(Integer, primary_key=True)
+    filename = Column(String(128), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    admin_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    file_hash = Column(String(64), nullable=False)
+
+    admin = db.relationship("User", lazy=True)
+


### PR DESCRIPTION
## Summary
- add `DatabaseBackup` model
- create `/api/admin/backup` blueprint for creating, listing, downloading and restoring backups
- register new blueprint in `create_app`

## Testing
- `pytest -q` *(fails: 13 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687a687ecec8832f9c9cd1211aae95b6