### PR TITLE
Add admin analytics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ pytest --cov=backend --cov=frontend tests/
 
 Backend API'lari OpenAPI (Swagger) standardina uygun sekilde belgelenmektedir. Calisan bir sunucu uzerinde `/api/docs` adresinden interaktif dokumanlara erisilebilir. Bu yontem frontend gelistiricileri icin net bir kontrat saglar ve API surumlerini takip etmeyi kolaylastirir.
 
+### Analytics Uc Noktalari
+
+Yonetim panelindeki gelismis raporlar icin eklenen API'lar:
+
+- `/api/admin/analytics/summary` – Belirli tarihler arasinda aktif kullanici, yeni kayit, odeme ve pasif kullanici sayilarini dondurur.
+- `/api/admin/analytics/plans` – Abonelik planlarina gore kullanici dagilimini listeler.
+- `/api/admin/analytics/usage` – Yapilan toplam tahmin ve sistem olayi sayisini dondurur.
+
 ## Guvenlik Notlari
 
 Sifreler `werkzeug` kutuphanesi ile guclu bicimde hashlenir ve JWT tabanli oturumlar kullanilir. Kullanici girislerinde olusan **refresh token** degeri `user_sessions` tablosunda saklanir ve token yenileme islemlerinde bu tablo uzerinden dogrulama yapilir. CSRF korumasi icin her istek `X-CSRF-Token` basligi ile dogrulanir. RBAC modeli ile yetki kontrolu saglanir. Flask-Limiter kullanilarak API istekleri oran sinirlariyla korunur. Hassas islemler Celery uzerinden gerceklestirilir ve kritik olaylarda `send_security_alert_task` tetiklenerek loglama yapilir.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -200,6 +200,7 @@ def create_app():
     from backend.api.admin.audit import audit_bp
     from backend.api.admin.backup import backup_bp
     from backend.api.admin.system_events import events_bp
+    from backend.api.admin.analytics import analytics_bp
     from backend.api.ta_routes import bp as ta_bp
     from backend.api.public.technical import technical_bp
     from backend.api.public.subscriptions import subscriptions_bp
@@ -221,6 +222,7 @@ def create_app():
     app.register_blueprint(audit_bp, url_prefix='/api')
     app.register_blueprint(backup_bp)
     app.register_blueprint(events_bp)
+    app.register_blueprint(analytics_bp)
     app.register_blueprint(ta_bp)
     app.register_blueprint(technical_bp)
     app.register_blueprint(subscriptions_bp)

--- a/backend/api/admin/analytics.py
+++ b/backend/api/admin/analytics.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required
+from sqlalchemy import func
+
+from backend.auth.middlewares import admin_required
+from backend.db import db
+from backend.db.models import (
+    User,
+    LoginAttempt,
+    PaymentTransactionLog,
+    PredictionOpportunity,
+    SystemEvent,
+)
+
+analytics_bp = Blueprint("analytics", __name__, url_prefix="/api/admin/analytics")
+
+
+@analytics_bp.route("/summary", methods=["GET"])
+@jwt_required()
+@admin_required()
+def summary():
+    start_str = request.args.get("from")
+    end_str = request.args.get("to")
+    try:
+        start = datetime.fromisoformat(start_str) if start_str else datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    except ValueError:
+        return jsonify({"error": "invalid from"}), 400
+    try:
+        end = datetime.fromisoformat(end_str) if end_str else datetime.utcnow()
+    except ValueError:
+        return jsonify({"error": "invalid to"}), 400
+
+    active_users = db.session.query(func.count(func.distinct(LoginAttempt.user_id))).filter(
+        LoginAttempt.success.is_(True),
+        LoginAttempt.created_at.between(start, end),
+    ).scalar() or 0
+
+    new_signups = db.session.query(func.count(User.id)).filter(
+        User.created_at.between(start, end)
+    ).scalar() or 0
+
+    payment_count = db.session.query(func.count(PaymentTransactionLog.id)).filter(
+        PaymentTransactionLog.created_at.between(start, end),
+        PaymentTransactionLog.status == "success",
+    ).scalar() or 0
+
+    churned = db.session.query(func.count(User.id)).filter(
+        User.is_active.is_(False)
+    ).scalar() or 0
+
+    return jsonify(
+        {
+            "active_users": active_users,
+            "new_signups": new_signups,
+            "successful_payments": payment_count,
+            "churned_users": churned,
+        }
+    )
+
+
+@analytics_bp.route("/plans", methods=["GET"])
+@jwt_required()
+@admin_required()
+def plan_distribution():
+    stats = db.session.query(
+        User.subscription_level,
+        func.count(User.id),
+    ).group_by(User.subscription_level).all()
+    result = [
+        {"plan": level.name if level else "Unknown", "count": count}
+        for level, count in stats
+    ]
+    return jsonify(result)
+
+
+@analytics_bp.route("/usage", methods=["GET"])
+@jwt_required()
+@admin_required()
+def usage_stats():
+    total_predictions = db.session.query(func.count(PredictionOpportunity.id)).scalar() or 0
+    total_events = db.session.query(func.count(SystemEvent.id)).scalar() or 0
+    return jsonify({"predictions": total_predictions, "system_events": total_events})


### PR DESCRIPTION
## Summary
- add new admin analytics blueprint with summary, plan distribution and usage routes
- register analytics blueprint in application factory
- document analytics API endpoints in README

## Testing
- `pytest -q` *(fails: tests/test_downgrade_task.py::test_downgrade_expired_subscription, tests/test_predictions_api.py::test_create_and_list_predictions, tests/test_predictions_api.py::test_update_and_delete_prediction, tests/test_predictions_api.py::test_filter_predictions_by_source_model, tests/test_rbac.py::test_admin_permission_denied, tests/test_sessions.py::test_login_creates_session_and_refresh, tests/test_sessions.py::test_refresh_rotates_session_token)*

------
https://chatgpt.com/codex/tasks/task_e_687ad71e0a48832f8542d37e5a140f5d