### PR TITLE
Add plan limit middleware with UsageLog

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -22,7 +22,7 @@ from backend.utils.usage_limits import check_usage_limit
 
 # Yardımcı fonksiyonları import et
 from backend.utils.helpers import serialize_user_for_api, add_audit_log
-from backend.utils.plan_limits import get_user_effective_limits
+from backend.utils.plan_limits import get_user_effective_limits, enforce_plan_limits
 
 # API Blueprint'i tanımla
 api_bp = Blueprint('api', __name__)
@@ -183,6 +183,14 @@ def llm_analyze():
             raise # Hatayı dışarı fırlat
 
     return jsonify({"result": simulated_result}), 200
+
+
+# Basit demo tahmin endpoint'i plan limitleri ile korunur
+@api_bp.route('/predict/', methods=['POST'])
+@require_subscription_plan(SubscriptionPlan.TRIAL)
+@enforce_plan_limits("predict_daily")
+def predict():
+    return jsonify({"result": "ok"}), 200
 
 # Basit çok günlü fiyat tahmini endpoint'i
 @api_bp.route('/forecast/<string:coin_id>', methods=['GET'])

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -621,6 +621,15 @@ class AuditLog(db.Model):
     user = db.relationship("User", backref="audit_logs", lazy=True)
 
 
+class UsageLog(db.Model):
+    __tablename__ = "usage_log"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, nullable=False)
+    action = Column(String(64), nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+
 class DatabaseBackup(db.Model):
     """Stores database backup metadata."""
 

--- a/tests/test_plan_limits.py
+++ b/tests/test_plan_limits.py
@@ -4,7 +4,42 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from backend import create_app, db
 from backend.db.models import User, Role, UserRole
 from backend.models.plan import Plan
+from flask import g
+import flask_jwt_extended
 from backend.utils.plan_limits import get_user_effective_limits, give_user_boost
+from backend.db.models import UsageLog
+
+
+def create_test_client(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setattr(flask_jwt_extended, "jwt_required", lambda *a, **k: (lambda f: f))
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.create_all()
+    return app.test_client()
+
+
+def create_user(app, plan="basic"):
+    with app.app_context():
+        role = Role.query.filter_by(name="user").first()
+        if not role:
+            role = Role(name="user")
+            db.session.add(role)
+            db.session.commit()
+        user = User(username="planuser", api_key="apikey", role_id=role.id, role=UserRole.USER)
+        user.set_password("pass")
+        db.session.add(user)
+        db.session.commit()
+    return user
+
+
+def log_usage(app, user_id, action):
+    with app.app_context():
+        log = UsageLog(user_id=user_id, action=action, timestamp=datetime.utcnow())
+        db.session.add(log)
+        db.session.commit()
 
 
 def setup_app(monkeypatch):
@@ -26,3 +61,15 @@ def test_effective_limits_with_boost(monkeypatch):
         give_user_boost(user, {"max_prediction_per_day": 10}, datetime.utcnow() + timedelta(days=1))
         limits = get_user_effective_limits(user)
         assert limits["max_prediction_per_day"] == 10
+
+
+def test_plan_limit_exceeded(monkeypatch):
+    client = create_test_client(monkeypatch)
+    app = client.application
+    user = create_user(app)
+
+    for _ in range(10):
+        log_usage(app, user.id, "predict_daily")
+
+    resp = client.post("/api/predict/", headers={"X-API-KEY": user.api_key})
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- create UsageLog model
- implement enforce_plan_limits decorator with plan limits
- add `/predict/` endpoint using the new middleware
- test exceeding plan limit

## Testing
- `pytest tests/test_plan_limits.py::test_plan_limit_exceeded -q`


------
https://chatgpt.com/codex/tasks/task_e_687cdd13c02c832faf6b26c91c69f2c1