### PR TITLE
Add PlanLimitEditor component

### DIFF
--- a/frontend/react/PlanLimitEditor.tsx
+++ b/frontend/react/PlanLimitEditor.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Input } from 'reactstrap';
+
+export default function PlanLimitEditor() {
+  const [plans, setPlans] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [resultMsg, setResultMsg] = useState('');
+
+  useEffect(() => {
+    fetch('/api/admin/plans')
+      .then(res => res.json())
+      .then(data => {
+        setPlans(data.plans);
+      });
+  }, []);
+
+  const updateLimit = (planId: number, field: string, value: any) => {
+    setPlans(prev =>
+      prev.map(p => (p.id === planId ? { ...p, features: { ...p.features, [field]: value } } : p))
+    );
+  };
+
+  const saveChanges = async (planId: number) => {
+    const plan = plans.find(p => p.id === planId);
+    setLoading(true);
+    try {
+      const resp = await fetch(`/api/admin/plans/${planId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ features: plan!.features })
+      });
+      const res = await resp.json();
+      if (res.ok) setResultMsg('Kaydedildi');
+      else setResultMsg('Hata');
+    } catch (e) {
+      setResultMsg('Sunucu hatası');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-bold mb-4">Plan Limitleri</h2>
+      {plans.map(plan => (
+        <div key={plan.id} className="border p-4 mb-4 rounded">
+          <h3 className="font-semibold mb-2">{plan.name}</h3>
+          <div className="grid grid-cols-2 gap-4">
+            {Object.entries(plan.features).map(([key, val]) => (
+              <div key={key}>
+                <label className="block text-sm font-medium">{key}</label>
+                <Input
+                  type="number"
+                  value={val}
+                  onChange={e => updateLimit(plan.id, key, Number(e.target.value))}
+                />
+              </div>
+            ))}
+          </div>
+          <Button className="mt-4" onClick={() => saveChanges(plan.id)} disabled={loading}>Kaydet</Button>
+        </div>
+      ))}
+      {resultMsg && <div className="mt-2 text-sm">{resultMsg}</div>}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/PlanLimitEditor.test.tsx
+++ b/frontend/src/pages/admin/PlanLimitEditor.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import PlanLimitEditor from '../../../react/PlanLimitEditor';
+import React from 'react';
+import '@testing-library/jest-dom';
+
+jest.mock('reactstrap', () => ({
+  Button: (props: any) => <button {...props} />,
+  Input: (props: any) => <input {...props} />,
+}));
+
+beforeAll(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ plans: [{ id: 1, name: 'Basic', features: { a: 1 } }] }),
+      ok: true,
+    })
+  ) as any;
+});
+
+test('renders save button', async () => {
+  render(<PlanLimitEditor />);
+  const btn = await screen.findByText(/Kaydet/i);
+  expect(btn).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add PlanLimitEditor React component
- test PlanLimitEditor with React Testing Library

## Testing
- `flake8 backend`
- `pytest -q` *(fails: downgrade_expired_subscription, predictions API, RBAC and session tests)*
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687ce47083cc832f9b9f2e1d5f40647b