### PR TITLE
Add Plan Limitleri React section

### DIFF
--- a/frontend/ytdcrypto-admin-dashboard..html
+++ b/frontend/ytdcrypto-admin-dashboard..html
@@ -7,6 +7,10 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/reactstrap@9/dist/reactstrap.min.js" crossorigin></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -162,6 +166,10 @@
                 <a href="#" class="nav-link flex items-center p-3 rounded-lg hover:bg-slate-800 transition-colors" data-section="yedekleme">
                     <i data-lucide="cloud-download" class="w-5 h-5 mr-3"></i>
                     Yedekleme & Geri Yükleme
+                </a>
+                <a href="#" class="nav-link flex items-center p-3 rounded-lg hover:bg-slate-800 transition-colors" data-section="plan-limitleri">
+                    <i data-lucide="sliders" class="w-5 h-5 mr-3"></i>
+                    Plan Limitleri
                 </a>
             </nav>
         </aside>
@@ -530,6 +538,9 @@
                         <button class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded-md mt-4 md:mt-0">Geri Yükle</button>
                         <p class="text-sm text-slate-500 mt-4">Son Yedekleme: 2025-06-25 03:00:00 (Başarılı)</p>
                     </div>
+                </section>
+                <section id="plan-limitleri" class="content-section hidden">
+                    <div id="plan-limit-editor-root"></div>
                 </section>
             </main>
         </div>
@@ -1088,6 +1099,81 @@
                 }
             });
         });
+    </script>
+    <script type="text/babel" data-plugins="transform-typescript" data-presets="react">
+        const { Button, Input } = Reactstrap;
+
+        function PlanLimitEditor() {
+            const [plans, setPlans] = React.useState<any[]>([]);
+            const [loading, setLoading] = React.useState(false);
+            const [resultMsg, setResultMsg] = React.useState('');
+
+            React.useEffect(() => {
+                fetch('/api/admin/plans')
+                    .then(res => {
+                        if (!res.ok) throw new Error('Plan verisi alınamadı');
+                        return res.json();
+                    })
+                    .then(data => {
+                        setPlans(data.plans);
+                    })
+                    .catch(() => setResultMsg('Planlar yüklenemedi'));
+            }, []);
+
+            const updateLimit = (planId: number, field: string, value: any) => {
+                setPlans(prev => prev.map(p => (
+                    p.id === planId ? { ...p, features: { ...p.features, [field]: value } } : p
+                )));
+            };
+
+            const saveChanges = async (planId: number) => {
+                const plan = plans.find(p => p.id === planId);
+                setLoading(true);
+                try {
+                    const resp = await fetch(`/api/admin/plans/${planId}`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ features: plan?.features })
+                    });
+                    if (!resp.ok) throw new Error('Sunucu hatası');
+                    const res = await resp.json();
+                    if (res.ok) setResultMsg('Kaydedildi');
+                    else setResultMsg('Hata');
+                } catch (e) {
+                    setResultMsg('Sunucu hatası');
+                }
+                setLoading(false);
+            };
+
+            return (
+                <div className="p-6">
+                    <h2 className="text-xl font-bold mb-4">Plan Limitleri</h2>
+                    {plans.map(plan => {
+                        const featuresObj = typeof plan.features === 'string'
+                            ? JSON.parse(plan.features || '{}')
+                            : (plan.features || {});
+                        return (
+                            <div key={plan.id} className="border p-4 mb-4 rounded">
+                                <h3 className="font-semibold mb-2">{plan.name}</h3>
+                                <div className="grid grid-cols-2 gap-4">
+                                    {Object.entries(featuresObj).map(([key, val]) => (
+                                        <div key={key}>
+                                            <label className="block text-sm font-medium">{key}</label>
+                                            <Input type="number" value={val} onChange={e => updateLimit(plan.id, key, Number(e.target.value))} />
+                                        </div>
+                                    ))}
+                                </div>
+                                <Button className="mt-4" onClick={() => saveChanges(plan.id)} disabled={loading}>Kaydet</Button>
+                            </div>
+                        );
+                    })}
+                    {resultMsg && <div className="mt-2 text-sm">{resultMsg}</div>}
+                </div>
+            );
+        }
+
+        const planLimitRoot = ReactDOM.createRoot(document.getElementById('plan-limit-editor-root'));
+        planLimitRoot.render(<PlanLimitEditor />);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load React, ReactDOM, Reactstrap and Babel in the admin dashboard
- add `Plan Limitleri` link in sidebar navigation
- create `plan-limitleri` section and render `PlanLimitEditor` React component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687cf33201d0832fb42802573091d6b6