### PR TITLE
Add plan limit editor page

### DIFF
--- a/frontend/admin/plan-limit-editor.html
+++ b/frontend/admin/plan-limit-editor.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Plan Limitleri</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/reactstrap@9/dist/reactstrap.min.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="bg-gray-100 p-4">
+  <div id="plan-limit-root"></div>
+  <script type="text/babel" data-plugins="transform-typescript" data-presets="react">
+import React, { useEffect, useState } from 'react';
+const { Button, Input } = Reactstrap;
+
+function PlanLimitEditor() {
+  const [plans, setPlans] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [resultMsg, setResultMsg] = useState('');
+
+  useEffect(() => {
+    fetch('/api/admin/plans')
+      .then(res => {
+        if (!res.ok) throw new Error('Plan verisi alınamadı');
+        return res.json();
+      })
+      .then(data => {
+        setPlans(data.plans);
+      })
+      .catch(() => setResultMsg('Planlar yüklenemedi'));
+  }, []);
+
+  const updateLimit = (planId: number, field: string, value: any) => {
+    setPlans(prev =>
+      prev.map(p => (p.id === planId ? { ...p, features: { ...p.features, [field]: value } } : p))
+    );
+  };
+
+  const saveChanges = async (planId: number) => {
+    const plan = plans.find(p => p.id === planId);
+    setLoading(true);
+    try {
+      const resp = await fetch(`/api/admin/plans/${planId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ features: plan?.features })
+      });
+      if (!resp.ok) throw new Error('Sunucu hatası');
+      const res = await resp.json();
+      if (res.ok) setResultMsg('Kaydedildi');
+      else setResultMsg('Hata');
+    } catch (e) {
+      setResultMsg('Sunucu hatası');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-bold mb-4">Plan Limitleri</h2>
+      {plans.map(plan => {
+        const featuresObj =
+          typeof plan.features === 'string'
+            ? JSON.parse(plan.features || '{}')
+            : plan.features || {};
+
+        return (
+          <div key={plan.id} className="border p-4 mb-4 rounded">
+            <h3 className="font-semibold mb-2">{plan.name}</h3>
+            <div className="grid grid-cols-2 gap-4">
+              {Object.entries(featuresObj).map(([key, val]) => (
+                <div key={key}>
+                  <label className="block text-sm font-medium">{key}</label>
+                  <Input
+                    type="number"
+                    value={val}
+                    onChange={e => updateLimit(plan.id, key, Number(e.target.value))}
+                  />
+                </div>
+              ))}
+            </div>
+            <Button className="mt-4" onClick={() => saveChanges(plan.id)} disabled={loading}>Kaydet</Button>
+          </div>
+        );
+      })}
+      {resultMsg && <div className="mt-2 text-sm">{resultMsg}</div>}
+    </div>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('plan-limit-root'));
+root.render(<PlanLimitEditor />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone HTML page integrating PlanLimitEditor React component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687cf7bc234c832fab0a1c7ae056bcf1