### PR TITLE
Add plan limit middleware

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -22,7 +22,8 @@ from backend.utils.usage_limits import check_usage_limit
 
 # Yardımcı fonksiyonları import et
 from backend.utils.helpers import serialize_user_for_api, add_audit_log
-from backend.utils.plan_limits import get_user_effective_limits, enforce_plan_limits
+from backend.utils.plan_limits import get_user_effective_limits
+from backend.middleware.plan_limits import enforce_plan_limit
 
 # API Blueprint'i tanımla
 api_bp = Blueprint('api', __name__)
@@ -188,7 +189,7 @@ def llm_analyze():
 # Basit demo tahmin endpoint'i plan limitleri ile korunur
 @api_bp.route('/predict/', methods=['POST'])
 @require_subscription_plan(SubscriptionPlan.TRIAL)
-@enforce_plan_limits("predict_daily")
+@enforce_plan_limit("prediction")
 def predict():
     return jsonify({"result": "ok"}), 200
 

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -153,6 +153,16 @@ class User(db.Model):
             return datetime.utcnow() < (self.created_at + trial_duration)
         return False
 
+    def get_usage_count(self, key):
+        """Return usage count for the given feature key."""
+        from backend.db.models import UsageLog
+
+        if key == "prediction":
+            return UsageLog.query.filter_by(user_id=self.id, action="prediction").count()
+        elif key == "download":
+            return UsageLog.query.filter_by(user_id=self.id, action="download").count()
+        return UsageLog.query.filter_by(user_id=self.id, action=key).count()
+
     def to_dict(self):
         return {
             "id": self.id,

--- a/backend/middleware/plan_limits.py
+++ b/backend/middleware/plan_limits.py
@@ -1,0 +1,42 @@
+from flask import request, jsonify, g
+from functools import wraps
+from backend.db.models import User
+import json
+
+
+def enforce_plan_limit(limit_key):
+    """Decorator to enforce subscription plan feature limits."""
+
+    def decorator(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            user = getattr(request, "current_user", None) or getattr(g, "user", None)
+            if not user:
+                api_key = request.headers.get("X-API-KEY")
+                if api_key:
+                    user = User.query.filter_by(api_key=api_key).first()
+                    if user:
+                        g.user = user
+            if not user or not user.plan or not user.plan.features:
+                return jsonify({"error": "Abonelik planı bulunamadı."}), 403
+
+            features = user.plan.features
+            if isinstance(features, str):
+                try:
+                    features = json.loads(features)
+                except Exception:
+                    return jsonify({"error": "Plan özellikleri okunamadı."}), 500
+
+            limit = features.get(limit_key)
+            if limit is None:
+                return jsonify({"error": f"{limit_key} limiti tanımlı değil."}), 403
+
+            current_count = user.get_usage_count(limit_key)
+            if current_count >= limit:
+                return jsonify({"error": f"{limit_key} limiti aşıldı. ({limit})"}), 429
+
+            return f(*args, **kwargs)
+
+        return wrapped
+
+    return decorator


### PR DESCRIPTION
## Summary
- add middleware for feature limit enforcement
- support usage count retrieval on `User`
- integrate new decorator in predict endpoint
- adjust plan limit tests for new limit

## Testing
- `pytest tests/test_plan_limits.py::test_plan_limit_exceeded -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0444c754832f96f8f2e0b501b548