### PR TITLE
Add limit usage stats view

### DIFF
--- a/frontend/react/LimitUsageStats.tsx
+++ b/frontend/react/LimitUsageStats.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+
+type Stat = {
+  user_id: number;
+  username: string;
+  action: string;
+  count: number;
+};
+
+export default function LimitUsageStats() {
+  const [stats, setStats] = useState<Stat[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    setLoading(true);
+    fetch('/api/admin/limit-usage')
+      .then((res) => {
+        if (!res.ok) throw new Error('Yükleme başarısız');
+        return res.json();
+      })
+      .then((data) => setStats(data.stats))
+      .catch(() => setError('Veri alınamadı'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-bold mb-4">Kullanım İstatistikleri</h2>
+      {loading && <p>Yükleniyor...</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      <table className="table-auto w-full text-sm">
+        <thead>
+          <tr>
+            <th className="px-4 py-2">Kullanıcı</th>
+            <th className="px-4 py-2">İşlem</th>
+            <th className="px-4 py-2">Kullanım</th>
+          </tr>
+        </thead>
+        <tbody>
+          {stats.map((stat) => (
+            <tr key={`${stat.user_id}-${stat.action}`}>
+              <td className="border px-4 py-2">{stat.username}</td>
+              <td className="border px-4 py-2">{stat.action}</td>
+              <td className="border px-4 py-2">{stat.count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/ytdcrypto-admin-dashboard..html
+++ b/frontend/ytdcrypto-admin-dashboard..html
@@ -171,6 +171,10 @@
                     <i data-lucide="sliders" class="w-5 h-5 mr-3"></i>
                     Plan Limitleri
                 </a>
+                <a href="#" class="nav-link flex items-center p-3 rounded-lg hover:bg-slate-800 transition-colors" data-section="limit-usage">
+                    <i data-lucide="bar-chart" class="w-5 h-5 mr-3"></i>
+                    Limit Kullanımı
+                </a>
             </nav>
         </aside>
 
@@ -541,6 +545,9 @@
                 </section>
                 <section id="plan-limitleri" class="content-section hidden">
                     <div id="plan-limit-editor-root"></div>
+                </section>
+                <section id="limit-usage" class="content-section hidden">
+                    <div id="limit-usage-root"></div>
                 </section>
             </main>
         </div>
@@ -1174,6 +1181,14 @@
 
         const planLimitRoot = ReactDOM.createRoot(document.getElementById('plan-limit-editor-root'));
         planLimitRoot.render(<PlanLimitEditor />);
+
+        const limitUsageRoot = document.getElementById('limit-usage-root');
+        if (limitUsageRoot) {
+          import('/react/LimitUsageStats.tsx').then((module) => {
+            const root = ReactDOM.createRoot(limitUsageRoot);
+            root.render(React.createElement(module.default));
+          });
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build a `LimitUsageStats` React component
- mount it in the admin dashboard
- expose new `/limit-usage` admin route

## Testing
- `pytest -q` *(fails: test_downgrade_expired_subscription, test_create_and_list_predictions, test_update_and_delete_prediction, test_filter_predictions_by_source_model, test_rbac_admin_permission_denied, test_login_creates_session_and_refresh, test_refresh_rotates_session_token)*

------
https://chatgpt.com/codex/tasks/task_e_687d0b4426b8832fbacc98ac881ecd3e