### PR TITLE
Add JSON validation and improved admin feature editor

### DIFF
--- a/backend/admin_panel/routes.py
+++ b/backend/admin_panel/routes.py
@@ -54,22 +54,25 @@ def list_users():
 
 @admin_bp.route('/users/<int:user_id>/custom-features', methods=['POST'])
 @admin_required
-def set_custom_features(user_id):
-    """Kullanıcıya özel custom_features tanımı yap."""
+def update_custom_features(user_id):
+    data = request.get_json()
+    if not data or "custom_features" not in data:
+        return jsonify({"error": "Eksik veri"}), 400
+
+    try:
+        parsed = json.loads(data["custom_features"])
+    except json.JSONDecodeError:
+        return jsonify({"error": "Geçersiz JSON"}), 400
+
     with current_app.app_context():
         user = User.query.get(user_id)
         if not user:
-            return jsonify({"error": "Kullanıcı bulunamadı."}), 404
-        data = request.get_json()
-        features = data.get("custom_features", "")
-        try:
-            # Geçerli bir JSON olup olmadığını kontrol et
-            json_obj = json.loads(features)
-            user.custom_features = json.dumps(json_obj)
-            db.session.commit()
-            return jsonify({"message": "Custom features güncellendi."}), 200
-        except Exception:
-            return jsonify({"error": "Geçersiz JSON"}), 400
+            return jsonify({"error": "Kullanıcı bulunamadı"}), 404
+
+        user.custom_features = json.dumps(parsed)
+        db.session.commit()
+
+    return jsonify({"message": "Özel özellikler güncellendi."}), 200
 
 # Kullanıcı detaylarını ve abonelik/rol güncelleme
 @admin_bp.route('/users/<int:user_id>', methods=['PUT'])

--- a/frontend/react/CustomFeaturesEditor.tsx
+++ b/frontend/react/CustomFeaturesEditor.tsx
@@ -14,6 +14,15 @@ export default function CustomFeaturesEditor() {
   const [customFeatures, setCustomFeatures] = useState<string>('{}');
   const [status, setStatus] = useState('');
 
+  function isValidJSON(str: string): boolean {
+    try {
+      JSON.parse(str);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   useEffect(() => {
     fetch('/api/admin/users')
       .then(res => res.json())
@@ -69,11 +78,30 @@ export default function CustomFeaturesEditor() {
             value={customFeatures}
             onChange={e => setCustomFeatures(e.target.value)}
           />
-          <Button onClick={saveCustomFeatures}>Kaydet</Button>
+          <Button
+            onClick={() => {
+              if (!isValidJSON(customFeatures)) {
+                setStatus('❌ Geçersiz JSON formatı');
+                return;
+              }
+              saveCustomFeatures();
+            }}
+            color="primary"
+          >
+            Kaydet
+          </Button>
         </>
       )}
 
-      {status && <p className="mt-2 text-sm text-slate-400">{status}</p>}
+      {status && (
+        <p
+          className={`mt-2 text-sm ${
+            status.startsWith('❌') ? 'text-red-500' : 'text-green-400'
+          }`}
+        >
+          {status}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- validate JSON before sending admin custom feature updates
- show colored status indicator for custom feature editor
- ensure backend rejects invalid payloads and returns Turkish messages
- test updating custom features

## Testing
- `pytest -q` *(fails: 7 failed, 49 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687d2c73b8e0832fad5671180358ddeb