### PR TITLE
Add per-user limit helper

### DIFF
--- a/backend/utils/limits.py
+++ b/backend/utils/limits.py
@@ -1,0 +1,27 @@
+import json
+from backend.db.models import SubscriptionPlan
+from backend.utils.plan_limits import PLAN_LIMITS
+
+class SubscriptionPlanLimits:
+    """Provides plan based limit configurations."""
+
+    @staticmethod
+    def get_limits(plan: SubscriptionPlan) -> dict:
+        return PLAN_LIMITS.get(plan.name.lower(), {})
+
+def get_effective_limits(user):
+    """Kullanıcıya özel limit varsa onu, yoksa plan limitini döndür."""
+    if getattr(user, "custom_features", None):
+        try:
+            return json.loads(user.custom_features)
+        except Exception:
+            pass  # bozuk JSON varsa plan limitine düş
+    return SubscriptionPlanLimits.get_limits(user.subscription_level)
+
+def enforce_limit(user, key: str, usage_count: int) -> bool:
+    """Belirli bir limit için kullanıcının sınırı aşıp aşmadığını kontrol eder."""
+    limits = get_effective_limits(user)
+    limit_value = limits.get(key)
+    if limit_value is None:
+        return True  # sınırsız kullanım
+    return usage_count < limit_value

--- a/tests/test_limit_override.py
+++ b/tests/test_limit_override.py
@@ -1,0 +1,30 @@
+import json
+from backend.db.models import User, SubscriptionPlan
+from backend.utils.limits import enforce_limit
+
+
+def test_enforce_limit_with_custom_override():
+    user = User(username="premium_user", subscription_level=SubscriptionPlan.PREMIUM)
+    user.custom_features = json.dumps({"predict_daily": 2})
+    assert enforce_limit(user, "predict_daily", usage_count=1)
+    assert not enforce_limit(user, "predict_daily", usage_count=2)
+
+
+def test_enforce_limit_fallback_to_plan(monkeypatch):
+    class MockSubscriptionPlanLimits:
+        @staticmethod
+        def get_limits(plan):
+            return {"predict_daily": 5}
+
+    monkeypatch.setattr("backend.utils.limits.SubscriptionPlanLimits", MockSubscriptionPlanLimits)
+
+    user = User(username="basic_user", subscription_level=SubscriptionPlan.BASIC)
+    user.custom_features = None
+    assert enforce_limit(user, "predict_daily", usage_count=4)
+    assert not enforce_limit(user, "predict_daily", usage_count=5)
+
+
+def test_enforce_limit_malformed_json():
+    user = User(username="corrupted", subscription_level=SubscriptionPlan.BASIC)
+    user.custom_features = "{invalid_json: true"
+    assert enforce_limit(user, "predict_daily", usage_count=0)


### PR DESCRIPTION
## Summary
- create `SubscriptionPlanLimits` helper for plan defaults
- allow checking user-specific limits via `enforce_limit`
- test limit override logic

## Testing
- `pytest tests/test_limit_override.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d32d9bf8c832fb93266275fe25c7c