### PR TITLE
Add plan limits hook

### DIFF
--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -35,6 +35,15 @@ class SubscriptionPlan(Enum):
     PREMIUM = 3
 
 
+class SubscriptionPlanLimits:
+    """Provides plan based limit configurations."""
+
+    @staticmethod
+    def get_limits(plan: SubscriptionPlan) -> dict:
+        from backend.utils.plan_limits import PLAN_LIMITS
+        return PLAN_LIMITS.get(plan.name.lower(), {})
+
+
 class UserRole(Enum):
     """Kullanıcı Rolü Enum'u (Yönetici Paneli için)"""
 

--- a/backend/utils/limits.py
+++ b/backend/utils/limits.py
@@ -1,16 +1,10 @@
 import json
-from backend.db.models import SubscriptionPlan
-from backend.utils.plan_limits import PLAN_LIMITS
-
-class SubscriptionPlanLimits:
-    """Provides plan based limit configurations."""
-
-    @staticmethod
-    def get_limits(plan: SubscriptionPlan) -> dict:
-        return PLAN_LIMITS.get(plan.name.lower(), {})
+from backend.db.models import SubscriptionPlanLimits
 
 def get_effective_limits(user):
-    """Kullanıcıya özel limit varsa onu, yoksa plan limitini döndür."""
+    """
+    Kullanıcıya özel limit varsa onu döndür, yoksa plan bazlı limitleri döndür.
+    """
     if getattr(user, "custom_features", None):
         try:
             return json.loads(user.custom_features)
@@ -19,7 +13,9 @@ def get_effective_limits(user):
     return SubscriptionPlanLimits.get_limits(user.subscription_level)
 
 def enforce_limit(user, key: str, usage_count: int) -> bool:
-    """Belirli bir limit için kullanıcının sınırı aşıp aşmadığını kontrol eder."""
+    """
+    Belirli bir limit anahtarı için kullanıcının limiti aşıp aşmadığını kontrol eder.
+    """
     limits = get_effective_limits(user)
     limit_value = limits.get(key)
     if limit_value is None:


### PR DESCRIPTION
## Summary
- import plan limits from the models package
- add a `SubscriptionPlanLimits` helper inside `backend.db.models`
- adjust `limits` helper docstrings

## Testing
- `pytest tests/test_limit_override.py::test_enforce_limit_with_custom_override -q`
- `pytest -q` *(fails: test_downgrade_expired_subscription, test_create_and_list_predictions, test_update_and_delete_prediction, test_filter_predictions_by_source_model, test_admin_permission_denied, test_login_creates_session_and_refresh, test_refresh_rotates_session_token)*

------
https://chatgpt.com/codex/tasks/task_e_687d363e2f88832f90fd8866fdbdda93