### PR TITLE
Add tests for plan limit decorator

### DIFF
--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -3,24 +3,37 @@ import pytest
 
 from backend import create_app, db
 from backend.db.models import User, UserRole
+from backend.models.plan import Plan
 from backend.utils.limits import enforce_limit
+from backend.middleware.plan_limits import enforce_plan_limit
+from flask import jsonify
 
 @pytest.fixture
-def test_user(monkeypatch):
+def test_app(monkeypatch):
     monkeypatch.setenv("FLASK_ENV", "testing")
     app = create_app()
-    app.config['TESTING'] = True
+    app.config["TESTING"] = True
     with app.app_context():
         db.create_all()
-        user = User(username="limit_user", subscription_level="BASIC", role=UserRole.USER)
-        user.set_password("pass")
-        user.generate_api_key()
-        user.custom_features = json.dumps({"predict_daily": 3})
-        db.session.add(user)
-        db.session.commit()
-        yield user
+        yield app
         db.session.remove()
         db.drop_all()
+
+
+@pytest.fixture
+def test_user(test_app):
+    with test_app.app_context():
+        plan = Plan(name="basic", price=0.0, features=json.dumps({"predict_daily": 5}))
+        db.session.add(plan)
+        db.session.commit()
+
+        user = User(username="limit_user", subscription_level="BASIC", role=UserRole.USER, plan_id=plan.id)
+        user.custom_features = json.dumps({"predict_daily": 3})
+        user.set_password("pass")
+        user.generate_api_key()
+        db.session.add(user)
+        db.session.commit()
+        return user
 
 def test_enforce_limit_allows_usage(test_user):
     assert enforce_limit(test_user, "predict_daily", 2) is True
@@ -30,3 +43,16 @@ def test_enforce_limit_denies_usage(test_user):
 
 def test_enforce_limit_with_missing_key_allows(test_user):
     assert enforce_limit(test_user, "unknown_limit", 999) is True
+
+
+def test_enforce_plan_limit_decorator_behavior(test_app, test_user):
+    app = test_app
+
+    @app.route("/test-decorated", methods=["POST"])
+    @enforce_plan_limit("predict_daily")
+    def decorated_route():
+        return jsonify({"message": "OK"}), 200
+
+    with app.test_client() as client:
+        response = client.post("/test-decorated", headers={"X-API-KEY": test_user.api_key})
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- ensure `enforce_plan_limit` decorator works with API key header
- create helper fixtures for app and user including a plan

## Testing
- `pytest tests/test_limits.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d587e194c832fa7648516e689dd81