### PR TITLE
Drop subscription_plan_limits table

### DIFF
--- a/migrations/versions/remove_subscription_plan_limits_table.py
+++ b/migrations/versions/remove_subscription_plan_limits_table.py
@@ -1,0 +1,26 @@
+"""
+Migration: Drop subscription_plan_limits table
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'remove_subscription_plan_limits'
+down_revision = 'previous_revision_id'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.drop_table('subscription_plan_limits')
+
+def downgrade():
+    op.create_table(
+        'subscription_plan_limits',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('plan_name', sa.String(length=50), nullable=False),
+        sa.Column('limits_json', sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('plan_name')
+    )
+


### PR DESCRIPTION
## Summary
- add alembic migration to remove the `subscription_plan_limits` table

## Testing
- `pytest -q` *(fails: AssertionError, DetachedInstanceError, AttributeError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687e3c6e6080832fb263b931eb036e1d