### PR TITLE
Add usage count helper and tests

### DIFF
--- a/backend/utils/usage_limits.py
+++ b/backend/utils/usage_limits.py
@@ -2,7 +2,7 @@ from functools import wraps
 from flask import g, request, jsonify, current_app
 from datetime import datetime
 
-from backend.db.models import UsageLimitModel, SubscriptionPlan
+from backend.db.models import UsageLimitModel, SubscriptionPlan, UsageLog
 
 
 def check_usage_limit(feature_name):
@@ -72,3 +72,14 @@ def check_usage_limit(feature_name):
         return wrapper
 
     return decorator
+
+
+def get_usage_count(user, feature):
+    """Return today's usage count for the given feature."""
+    start_of_day = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    return (
+        UsageLog.query
+        .filter_by(user_id=user.id, action=feature)
+        .filter(UsageLog.timestamp >= start_of_day)
+        .count()
+    )

--- a/tests/test_usage_count.py
+++ b/tests/test_usage_count.py
@@ -1,0 +1,49 @@
+import pytest
+from datetime import datetime, timedelta
+from backend import create_app, db
+from backend.db.models import User, UsageLog, UserRole
+
+@pytest.fixture
+def test_app(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    app = create_app()
+    app.config['TESTING'] = True
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture
+def test_user(test_app):
+    with test_app.app_context():
+        user = User(username="usagetest", role=UserRole.USER)
+        user.set_password("pass")
+        user.generate_api_key()
+        db.session.add(user)
+        db.session.commit()
+        return user
+
+def test_get_usage_count(test_app, test_user):
+    from backend.utils.usage_limits import get_usage_count
+
+    with test_app.app_context():
+        now = datetime.utcnow()
+        yesterday = now - timedelta(days=1)
+        db.session.add_all([
+            UsageLog(user_id=test_user.id, action="predict_daily", timestamp=now),
+            UsageLog(user_id=test_user.id, action="predict_daily", timestamp=now),
+            UsageLog(user_id=test_user.id, action="predict_daily", timestamp=yesterday),
+            UsageLog(user_id=test_user.id, action="export", timestamp=now),
+        ])
+        db.session.commit()
+
+        count_today = get_usage_count(test_user, "predict_daily")
+        assert count_today == 2
+
+        export_count = get_usage_count(test_user, "export")
+        assert export_count == 1
+
+        unknown_count = get_usage_count(test_user, "non_existing")
+        assert unknown_count == 0


### PR DESCRIPTION
## Summary
- implement `get_usage_count` in `usage_limits`
- add unit test for usage counting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687eaa572b44832f98688c5ebbe8c0ae