### PR TITLE
Add usage tracking helper and tests

### DIFF
--- a/backend/utils/usage_tracking.py
+++ b/backend/utils/usage_tracking.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+from backend import db
+from backend.db.models import UsageLog
+
+
+def record_usage(user, action: str) -> UsageLog:
+    """Persist a usage log entry for the given user action."""
+    log = UsageLog(user_id=user.id, action=action, timestamp=datetime.utcnow())
+    db.session.add(log)
+    db.session.commit()
+    return log

--- a/tests/test_usage_count.py
+++ b/tests/test_usage_count.py
@@ -47,3 +47,21 @@ def test_get_usage_count(test_app, test_user):
 
         unknown_count = get_usage_count(test_user, "non_existing")
         assert unknown_count == 0
+
+
+def test_record_usage_log_insert(test_app, test_user):
+    from backend.utils.usage_tracking import record_usage
+
+    with test_app.app_context():
+        record_usage(test_user, "predict_daily")
+        record_usage(test_user, "predict_daily")
+        record_usage(test_user, "export")
+
+        logs = UsageLog.query.filter_by(user_id=test_user.id).all()
+        assert len(logs) == 3
+
+        daily_logs = [log for log in logs if log.action == "predict_daily"]
+        export_logs = [log for log in logs if log.action == "export"]
+
+        assert len(daily_logs) == 2
+        assert len(export_logs) == 1


### PR DESCRIPTION
## Summary
- implement `record_usage` helper
- expand usage count tests

## Testing
- `pytest tests/test_usage_count.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eaef03ce8832fbda7f3e5496b354f