### PR TITLE
Add usage logging tests and prediction logging

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -192,6 +192,10 @@ def llm_analyze():
 @require_subscription_plan(SubscriptionPlan.TRIAL)
 @enforce_plan_limit("prediction")
 def predict():
+    from backend.utils.usage_tracking import record_usage
+    user = g.get("user")
+    if user:
+        record_usage(user, "predict_daily")
     return jsonify({"result": "ok"}), 200
 
 @api_bp.route('/predict/daily', methods=['POST'])

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -148,6 +148,17 @@ class User(db.Model):
         self.api_key = str(uuid.uuid4())
         return self.api_key
 
+    def generate_access_token(self):
+        """Return a short-lived JWT access token for this user."""
+        from backend.auth.jwt_utils import generate_tokens
+
+        access, _refresh, _csrf = generate_tokens(
+            self.id,
+            self.username,
+            self.role.value if isinstance(self.role, Enum) else self.role,
+        )
+        return access
+
     def is_subscription_active(self):
         if self.subscription_level in [
             SubscriptionPlan.BASIC,

--- a/tests/test_usage_logging.py
+++ b/tests/test_usage_logging.py
@@ -1,0 +1,98 @@
+import pytest
+from datetime import datetime, timedelta
+from backend import create_app, db
+from backend.db.models import User, UsageLog, UserRole, SubscriptionPlan
+
+
+@pytest.fixture
+def test_app(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    app = create_app()
+    app.config['TESTING'] = True
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def test_user(test_app):
+    with test_app.app_context():
+        # create a basic plan with prediction limits so enforce_plan_limit passes
+        from backend.models.plan import Plan
+        import json
+        plan = Plan(name="basic", price=0.0, features=json.dumps({"prediction": 5, "predict_daily": 5}))
+        db.session.add(plan)
+        db.session.commit()
+
+        user = User(username="usagetest", role=UserRole.USER, plan_id=plan.id, subscription_level=SubscriptionPlan.BASIC)
+        user.set_password("pass")
+        user.generate_api_key()
+        db.session.add(user)
+        db.session.commit()
+        return user
+
+
+def test_get_usage_count(test_app, test_user):
+    from backend.utils.usage_limits import get_usage_count
+
+    with test_app.app_context():
+        now = datetime.utcnow()
+        yesterday = now - timedelta(days=1)
+        db.session.add_all([
+            UsageLog(user_id=test_user.id, action="predict_daily", timestamp=now),
+            UsageLog(user_id=test_user.id, action="predict_daily", timestamp=now),
+            UsageLog(user_id=test_user.id, action="predict_daily", timestamp=yesterday),
+            UsageLog(user_id=test_user.id, action="export", timestamp=now),
+        ])
+        db.session.commit()
+
+        count_today = get_usage_count(test_user, "predict_daily")
+        assert count_today == 2
+
+        export_count = get_usage_count(test_user, "export")
+        assert export_count == 1
+
+        unknown_count = get_usage_count(test_user, "non_existing")
+        assert unknown_count == 0
+
+
+def test_record_usage_log_insert(test_app, test_user):
+    from backend.utils.usage_tracking import record_usage
+
+    with test_app.app_context():
+        record_usage(test_user, "predict_daily")
+        record_usage(test_user, "predict_daily")
+        record_usage(test_user, "export")
+
+        logs = UsageLog.query.filter_by(user_id=test_user.id).all()
+        assert len(logs) == 3
+
+        daily_logs = [log for log in logs if log.action == "predict_daily"]
+        export_logs = [log for log in logs if log.action == "export"]
+
+        assert len(daily_logs) == 2
+        assert len(export_logs) == 1
+
+
+def test_predict_usage_log(test_app, test_user):
+    from backend import db
+    from backend.db.models import UsageLog
+
+    with test_app.test_client() as client:
+        with test_app.app_context():
+            token = test_user.generate_access_token()
+            db.session.commit()
+
+            headers = {
+                "X-API-KEY": test_user.api_key,
+                "Content-Type": "application/json"
+            }
+            data = {"coin": "BTC"}
+            response = client.post("/api/predict/", json=data, headers=headers)
+            assert response.status_code == 200
+
+            logs = UsageLog.query.filter_by(user_id=test_user.id, action="predict_daily").all()
+            assert len(logs) == 1


### PR DESCRIPTION
## Summary
- add new test suite `tests/test_usage_logging.py`
- support generating short-lived JWTs on the `User` model
- log usage in `/api/predict/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6232061c832fa5c039cac7175f84