### PR TITLE
Add admin limit bypass

### DIFF
--- a/backend/middleware/plan_limits.py
+++ b/backend/middleware/plan_limits.py
@@ -1,6 +1,6 @@
 from flask import request, jsonify, g
 from functools import wraps
-from backend.db.models import User
+from backend.db.models import User, UserRole
 import json
 
 
@@ -19,6 +19,9 @@ def enforce_plan_limit(limit_key):
                         g.user = user
             if not user or not user.plan or not user.plan.features:
                 return jsonify({"error": "Abonelik planı bulunamadı."}), 403
+
+            if getattr(user, "role", None) == UserRole.ADMIN:
+                return f(*args, **kwargs)
 
             features = user.plan.features
             if isinstance(features, str):


### PR DESCRIPTION
## Summary
- allow admins to bypass plan usage limits
- add an admin fixture and a test ensuring admin users can bypass limits

## Testing
- `pytest -q tests/test_limit_enforcement.py::test_admin_bypass_limits -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbdc0c0cc832f924356ef069d1f9b