### PR TITLE
Add limits status API endpoint

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -245,6 +245,7 @@ def create_app():
     from backend.api.admin.backup import backup_bp
     from backend.api.admin.system_events import events_bp
     from backend.api.admin.analytics import analytics_bp
+    from backend.limits.routes import limits_bp
     from backend.api.ta_routes import bp as ta_bp
     from backend.api.public.technical import technical_bp
     from backend.api.public.subscriptions import subscriptions_bp
@@ -272,6 +273,7 @@ def create_app():
     app.register_blueprint(ta_bp)
     app.register_blueprint(technical_bp)
     app.register_blueprint(subscriptions_bp)
+    app.register_blueprint(limits_bp)
 
     # Sağlık Kontrol Endpoint'i
     @app.route("/health", methods=["GET"])

--- a/backend/limits/routes.py
+++ b/backend/limits/routes.py
@@ -1,0 +1,34 @@
+from flask import Blueprint, jsonify, g
+from flask_jwt_extended import jwt_required
+from backend.auth.jwt_utils import require_csrf
+from backend.utils.usage_limits import get_usage_count
+import json
+
+limits_bp = Blueprint("limits", __name__, url_prefix="/api/limits")
+
+
+@limits_bp.route("/status", methods=["GET"])
+@jwt_required()
+@require_csrf
+def get_limit_status():
+    user = g.user
+    features = user.plan.features
+    if isinstance(features, str):
+        try:
+            features = json.loads(features)
+        except Exception:
+            return jsonify({"error": "Plan özellikleri okunamadı."}), 500
+
+    result = {}
+    for key, limit in features.items():
+        used = get_usage_count(user, key)
+        remaining = max(limit - used, 0)
+        percent = int((used / limit) * 100) if limit > 0 else 0
+        result[key] = {
+            "limit": limit,
+            "used": used,
+            "remaining": remaining,
+            "percent_used": percent,
+        }
+
+    return jsonify({"limits": result})

--- a/tests/test_limit_status_api.py
+++ b/tests/test_limit_status_api.py
@@ -1,0 +1,63 @@
+import json
+from datetime import datetime
+
+import flask_jwt_extended
+import pytest
+
+from backend import create_app, db
+from flask import g
+from backend.db.models import User, UsageLog, Role, UserRole
+from backend.models.plan import Plan
+
+
+@pytest.fixture
+def test_app(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setattr(flask_jwt_extended, "jwt_required", lambda *a, **k: (lambda f: f))
+    monkeypatch.setattr("backend.auth.jwt_utils.require_csrf", lambda f: f)
+    app = create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def test_user(test_app):
+    with test_app.app_context():
+        role = Role.query.filter_by(name="user").first()
+        plan = Plan(name="basic", price=0.0, features=json.dumps({"predict_daily": 5}))
+        db.session.add(plan)
+        db.session.commit()
+        user = User(username="limitstatus", role=UserRole.USER, plan_id=plan.id)
+        user.set_password("pass")
+        user.generate_api_key()
+        db.session.add(user)
+        db.session.commit()
+        return user
+
+
+def test_limit_status_endpoint(test_app, test_user):
+    with test_app.app_context():
+        db.session.add(
+            UsageLog(user_id=test_user.id, action="predict_daily", timestamp=datetime.utcnow())
+        )
+        db.session.commit()
+        token = test_user.generate_access_token()
+    client = test_app.test_client()
+    with test_app.app_context():
+        g.user = db.session.merge(test_user)
+        resp = client.get(
+            "/api/limits/status",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "X-API-KEY": test_user.api_key,
+                "X-CSRF-TOKEN": "test",
+            },
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["limits"]["predict_daily"]["used"] == 1
+    assert data["limits"]["predict_daily"]["remaining"] == 4


### PR DESCRIPTION
## Summary
- expose `/api/limits/status` endpoint to return usage stats
- register new blueprint in the Flask app
- add test for limit status API

## Testing
- `pytest tests/test_limit_status_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687fcf987e84832fa062e092769f72ef