### PR TITLE
Add useLimitStatus hook

### DIFF
--- a/frontend/react/hooks/useLimitStatus.ts
+++ b/frontend/react/hooks/useLimitStatus.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+interface LimitInfo {
+  limit: number;
+  used: number;
+  remaining: number;
+  percent_used: number;
+}
+
+export default function useLimitStatus() {
+  const [limits, setLimits] = useState<Record<string, LimitInfo> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchLimits = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const token = localStorage.getItem('access_token');
+        const apiKey = localStorage.getItem('api_key');
+        const res = await fetch('/api/limits/status', {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'X-API-KEY': apiKey || '',
+            'X-CSRF-TOKEN': 'test',
+          },
+        });
+        if (!res.ok) throw new Error('Failed to load');
+        const data = await res.json();
+        setLimits(data.limits);
+      } catch (err: any) {
+        setError(err.message || 'error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchLimits();
+  }, []);
+
+  return { limits, loading, error };
+}

--- a/frontend/tests/useLimitStatus.test.tsx
+++ b/frontend/tests/useLimitStatus.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import useLimitStatus from '../react/hooks/useLimitStatus';
+
+describe('useLimitStatus', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ limits: { test: { limit: 5, used: 0, remaining: 5, percent_used: 0 } } })
+      })
+    ) as any;
+    Storage.prototype.getItem = jest.fn(() => 'token');
+  });
+
+  it('fetches limits on mount', async () => {
+    const { result } = renderHook(() => useLimitStatus());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.limits).toHaveProperty('test');
+  });
+});


### PR DESCRIPTION
## Summary
- add a React hook `useLimitStatus` to query limit status
- add tests for the hook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd788ce1c832fbf9d4d961dc2a787