### PR TITLE
Add PlanLimitCard component

### DIFF
--- a/frontend/react/PlanLimitCard.tsx
+++ b/frontend/react/PlanLimitCard.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import useLimitStatus from './hooks/useLimitStatus';
+import { Card, CardBody, Progress } from 'reactstrap';
+
+export default function PlanLimitCard() {
+  const { limits, loading, error } = useLimitStatus();
+
+  if (loading) return <div>Yükleniyor...</div>;
+  if (error || !limits) return <div>Limit bilgileri alınamadı</div>;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {Object.entries(limits).map(([key, info]) => (
+        <Card key={key} className="shadow-sm border">
+          <CardBody className="py-4">
+            <div className="text-sm text-muted-foreground font-medium mb-1">
+              {key.replace(/_/g, ' ').toUpperCase()}
+            </div>
+            <div className="flex justify-between text-xs mb-1">
+              <span>İzin: {info.used} / {info.limit}</span>
+              <span>{info.remaining} kaldı</span>
+            </div>
+            <Progress value={info.percent_used} />
+          </CardBody>
+        </Card>
+        ))}
+      </div>
+    );
+  }

--- a/frontend/tests/PlanLimitCard.test.tsx
+++ b/frontend/tests/PlanLimitCard.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import PlanLimitCard from '../react/PlanLimitCard';
+
+jest.mock('reactstrap', () => ({
+  Card: (props: any) => <div {...props} />,
+  CardBody: (props: any) => <div {...props} />,
+  Progress: ({ value }: any) => <div data-testid="progress">{value}</div>,
+}));
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          limits: { test_feature: { limit: 5, used: 2, remaining: 3, percent_used: 40 } },
+        }),
+    })
+  ) as any;
+  Storage.prototype.getItem = jest.fn(() => 'token');
+});
+
+test('renders limit info after load', async () => {
+  render(<PlanLimitCard />);
+  expect(await screen.findByText('İzin: 2 / 5')).toBeInTheDocument();
+  expect(screen.getByTestId('progress')).toHaveTextContent('40');
+});


### PR DESCRIPTION
## Summary
- add a new `PlanLimitCard` React component to show limit status
- add corresponding unit test

## Testing
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687fdde9b3b4832f9f053321a180952f