### PR TITLE
Add PlanLimitCard React component

### DIFF
--- a/frontend/react/PlanLimitCard.tsx
+++ b/frontend/react/PlanLimitCard.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import useLimitStatus from './hooks/useLimitStatus';
+import { Card, CardBody, Progress } from 'reactstrap';
+
+export default function PlanLimitCard() {
+  const { limits, loading, error } = useLimitStatus();
+
+  if (loading) return <div>Yükleniyor...</div>;
+  if (error || !limits) return <div>Limit bilgileri alınamadı</div>;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {Object.entries(limits).map(([key, info]) => (
+        <Card key={key} className="shadow-sm border">
+          <CardBody className="py-4">
+            <div className="text-sm text-muted-foreground font-medium mb-1">
+              {key.replace(/_/g, ' ').toUpperCase()}
+            </div>
+            <div className="flex justify-between text-xs mb-1">
+              <span>İzin: {info.used} / {info.limit}</span>
+              <span>{info.remaining} kaldı</span>
+            </div>
+            <Progress value={info.percent_used} />
+          </CardBody>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/frontend/tests/PlanLimitCard.test.tsx
+++ b/frontend/tests/PlanLimitCard.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import PlanLimitCard from '../react/PlanLimitCard';
+import useLimitStatus from '../react/hooks/useLimitStatus';
+
+jest.mock('../react/hooks/useLimitStatus', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+const mockedHook = useLimitStatus as jest.MockedFunction<typeof useLimitStatus>;
+
+jest.mock('reactstrap', () => ({
+  Card: (props: any) => <div {...props} />,
+  CardBody: (props: any) => <div {...props} />,
+  Progress: (props: any) => <div data-progress={props.value} />,
+}));
+
+describe('PlanLimitCard', () => {
+  it('shows loading state', () => {
+    mockedHook.mockReturnValue({ limits: null, loading: true, error: null });
+    render(<PlanLimitCard />);
+    expect(screen.getByText('Yükleniyor...')).toBeInTheDocument();
+  });
+
+  it('renders limit information', () => {
+    mockedHook.mockReturnValue({
+      limits: { test: { limit: 5, used: 2, remaining: 3, percent_used: 40 } },
+      loading: false,
+      error: null,
+    });
+    render(<PlanLimitCard />);
+    expect(screen.getByText('İzin: 2 / 5')).toBeInTheDocument();
+    expect(screen.getByText('3 kaldı')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a new `PlanLimitCard` component using Reactstrap
- include Jest tests for PlanLimitCard

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fdc262464832f8297e626ae7945da