### PR TITLE
Add Dashboard component linking PlanLimitCard

### DIFF
--- a/frontend/react/dashboard/Dashboard.tsx
+++ b/frontend/react/dashboard/Dashboard.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Card, CardContent } from '../components/ui/card';
+import { BarChart } from 'lucide-react';
+import PlanLimitCard from '../PlanLimitCard';
+
+export default function Dashboard() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Genel Bakış</h1>
+
+      {/* Kullanım limitleri */}
+      <PlanLimitCard />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Card>
+          <CardContent className="flex items-center gap-4 p-6">
+            <BarChart className="w-6 h-6 text-muted-foreground" />
+            <div>
+              <div className="text-sm text-muted-foreground">Toplam Tahmin</div>
+              <div className="text-xl font-semibold">132</div>
+            </div>
+          </CardContent>
+        </Card>
+        {/* Diğer kartlar... */}
+      </div>
+    </div>
+  );
+}

--- a/frontend/tests/Dashboard.test.tsx
+++ b/frontend/tests/Dashboard.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import Dashboard from '../react/dashboard/Dashboard';
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          limits: { test_feature: { limit: 5, used: 2, remaining: 3, percent_used: 40 } },
+        }),
+    })
+  ) as any;
+  Storage.prototype.getItem = jest.fn(() => 'token');
+});
+
+test('renders limit info inside dashboard', async () => {
+  render(<Dashboard />);
+  expect(await screen.findByText('Kullanım: 2 / 5')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add Dashboard React component to display usage limits and totals
- ensure PlanLimitCard renders inside Dashboard
- test Dashboard component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fef9254ec832f8ebfd47bdb405a88