### PR TITLE
Add progress warnings on plan limits

### DIFF
--- a/frontend/react/PlanLimitCard.tsx
+++ b/frontend/react/PlanLimitCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import useLimitStatus from './hooks/useLimitStatus';
 import { Card, CardContent } from './components/ui/card';
 import { Progress } from './components/ui/progress';
-import { Loader2, AlertTriangle, ShieldCheck } from 'lucide-react';
+import { Loader2, AlertTriangle, ShieldCheck, Bell, BellRing } from 'lucide-react';
 
 const limitLabels: Record<string, string> = {
   predict_daily: 'Günlük Tahmin',
@@ -47,25 +47,38 @@ export default function PlanLimitCard() {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {Object.entries(limits).map(([key, info]) => {
           const label = limitLabels[key] || key.replace(/_/g, ' ').toUpperCase();
-        const progressColor =
-          info.percent_used >= 90 ? 'bg-red-500'
-          : info.percent_used >= 75 ? 'bg-yellow-500'
-          : undefined;
+          const progressColor =
+            info.percent_used >= 100 ? 'bg-red-600'
+            : info.percent_used >= 90 ? 'bg-red-500'
+            : info.percent_used >= 75 ? 'bg-yellow-500'
+            : undefined;
 
-        return (
-          <Card key={key} className="shadow-sm border">
-            <CardContent className="py-4">
-              <div className="text-sm text-muted-foreground font-medium mb-1">
-                {label}
-              </div>
-              <div className="flex justify-between text-xs mb-1">
-                <span>Kullanım: {info.used} / {info.limit}</span>
-                <span>{info.remaining} kaldı</span>
-              </div>
-              <Progress value={info.percent_used} className={progressColor} />
-            </CardContent>
-          </Card>
-        );
+          const warningIcon =
+            info.percent_used >= 100 ? (
+              <BellRing className="w-4 h-4 text-red-600" title="Limit doldu" />
+            ) : info.percent_used >= 90 ? (
+              <Bell className="w-4 h-4 text-red-500" title="%90 kullanım" />
+            ) : info.percent_used >= 75 ? (
+              <Bell className="w-4 h-4 text-yellow-500" title="%75 kullanım" />
+            ) : null;
+
+          return (
+            <Card key={key} className="shadow-sm border">
+              <CardContent className="py-4">
+                <div className="flex items-center justify-between mb-1">
+                  <div className="text-sm text-muted-foreground font-medium">
+                    {label}
+                  </div>
+                  {warningIcon && <div>{warningIcon}</div>}
+                </div>
+                <div className="flex justify-between text-xs mb-1">
+                  <span>Kullanım: {info.used} / {info.limit}</span>
+                  <span>{info.remaining} kaldı</span>
+                </div>
+                <Progress value={info.percent_used} className={progressColor} />
+              </CardContent>
+            </Card>
+          );
         })}
       </div>
     </section>

--- a/frontend/tests/PlanLimitCard.test.tsx
+++ b/frontend/tests/PlanLimitCard.test.tsx
@@ -21,3 +21,31 @@ test('renders limit info after load', async () => {
   expect(await screen.findByText('Kullanım: 2 / 5')).toBeInTheDocument();
   expect(screen.getByTestId('progress')).toHaveStyle({ width: '40%' });
 });
+
+test('shows warning icon at 90 percent usage', async () => {
+  (global.fetch as jest.Mock).mockImplementationOnce(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          limits: { warn: { limit: 10, used: 9, remaining: 1, percent_used: 90 } },
+        }),
+    })
+  );
+  render(<PlanLimitCard />);
+  expect(await screen.findByTitle('%90 kullanım')).toBeInTheDocument();
+});
+
+test('shows bell ring icon at full usage', async () => {
+  (global.fetch as jest.Mock).mockImplementationOnce(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          limits: { full: { limit: 10, used: 10, remaining: 0, percent_used: 100 } },
+        }),
+    })
+  );
+  render(<PlanLimitCard />);
+  expect(await screen.findByTitle('Limit doldu')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add bell indicators for limit warnings
- test new warning behavior

## Testing
- `npm test` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687ff2a7a058832fbe423b69dd1e4847