### PR TITLE
Add admin jwt auth to plan limit update

### DIFF
--- a/backend/api/plan_admin_limits.py
+++ b/backend/api/plan_admin_limits.py
@@ -1,17 +1,17 @@
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required
-from backend.utils.decorators import admin_required
+from backend.auth.jwt_utils import require_csrf, require_admin
 from backend import db
 from backend.models.plan import Plan
 import json
-import logging
 
 plan_admin_limits_bp = Blueprint('plan_admin_limits', __name__, url_prefix='/api/plans')
 
 
 @plan_admin_limits_bp.route('/<int:plan_id>/update-limits', methods=['POST'])
 @jwt_required()
-@admin_required
+@require_csrf
+@require_admin
 def update_plan_limits(plan_id):
     try:
         plan = Plan.query.get(plan_id)
@@ -22,6 +22,7 @@ def update_plan_limits(plan_id):
         if not isinstance(new_limits, dict):
             return jsonify({"error": "Limit verileri geçersiz."}), 400
 
+        # Sayısal olmayan veya negatif limit değerlerini filtrele
         for key, val in new_limits.items():
             if not isinstance(val, int) or val < 0:
                 return jsonify({"error": f"'{key}' için geçersiz limit değeri."}), 400


### PR DESCRIPTION
## Summary
- secure plan limit update endpoint with require_csrf and require_admin
- update tests to handle new admin auth logic

## Testing
- `pytest -q tests/test_plan_admin_limits.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880bbdc1ce8832fbb9a082a13ef83a5