### PR TITLE
Remove unused variable

### DIFF
--- a/backend/api/plan_admin_limits.py
+++ b/backend/api/plan_admin_limits.py
@@ -27,7 +27,6 @@ def update_plan_limits(plan_id):
             if not isinstance(val, int) or val < 0:
                 return jsonify({"error": f"'{key}' için geçersiz limit değeri."}), 400
 
-        old_limits = json.loads(plan.features or '{}')
         plan.features = json.dumps(new_limits)
         db.session.commit()
 
@@ -42,7 +41,6 @@ def update_plan_limits(plan_id):
         })
     except Exception as e:
         db.session.rollback()
-        # TODO: handle logging
         return jsonify({"error": str(e)}), 500
 
 


### PR DESCRIPTION
## Summary
- remove `old_limits` unused variable from plan limit update handler

## Testing
- `pytest -q`
- `pytest tests/test_plan_admin_limits.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68813dae7558832fbf6b520c7001b94a