### PR TITLE
Enhance plan limit update endpoint

### DIFF
--- a/backend/api/plan_admin_limits.py
+++ b/backend/api/plan_admin_limits.py
@@ -5,10 +5,10 @@ from backend import db
 from backend.models.plan import Plan
 import json
 
-plan_admin_limits_bp = Blueprint('plan_admin_limits', __name__, url_prefix='/api/plans')
+plan_admin_limits_bp = Blueprint("plan_admin_limits", __name__, url_prefix="/api/plans")
 
 
-@plan_admin_limits_bp.route('/<int:plan_id>/update-limits', methods=['POST'])
+@plan_admin_limits_bp.route("/<int:plan_id>/update-limits", methods=["POST"])
 @jwt_required()
 @require_csrf
 @require_admin
@@ -27,24 +27,29 @@ def update_plan_limits(plan_id):
             if not isinstance(val, int) or val < 0:
                 return jsonify({"error": f"'{key}' için geçersiz limit değeri."}), 400
 
+        old_limits = json.loads(plan.features or "{}")
+
         plan.features = json.dumps(new_limits)
         db.session.commit()
 
-        return jsonify({
-            "success": True,
-            "message": "Plan limitleri güncellendi.",
-            "plan": {
-                "id": plan.id,
-                "name": plan.name,
-                "features": new_limits,
-            },
-        })
+        return jsonify(
+            {
+                "success": True,
+                "message": "Plan limitleri güncellendi.",
+                "plan": {
+                    "id": plan.id,
+                    "name": plan.name,
+                    "features": new_limits,
+                    "old_features": old_limits,
+                },
+            }
+        )
     except Exception as e:
         db.session.rollback()
         return jsonify({"error": str(e)}), 500
 
 
-@plan_admin_limits_bp.route('/all', methods=['GET'])
+@plan_admin_limits_bp.route("/all", methods=["GET"])
 @jwt_required()
 @require_csrf
 @require_admin
@@ -55,7 +60,7 @@ def get_all_plans():
             {
                 "id": plan.id,
                 "name": plan.name,
-                "features": json.loads(plan.features or '{}')
+                "features": json.loads(plan.features or "{}"),
             }
             for plan in plans
         ]


### PR DESCRIPTION
## Summary
- keep track of previous plan limits when updating
- include `old_features` in the JSON response
- verify updated behavior with unit tests

## Testing
- `pytest tests/test_plan_admin_limits.py::test_update_plan_limits tests/test_plan_admin_limits.py::test_get_all_plans -q`

------
https://chatgpt.com/codex/tasks/task_e_688140b3f294832fa74b64073575dc2f