### PR TITLE
Add plan creation and deletion APIs

### DIFF
--- a/backend/api/plan_admin_limits.py
+++ b/backend/api/plan_admin_limits.py
@@ -73,3 +73,56 @@ def get_all_plans():
         return jsonify(data)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+@plan_admin_limits_bp.route("/create", methods=["POST"])
+@jwt_required()
+@require_csrf
+@require_admin
+def create_plan():
+    """Create a new plan with optional feature limits."""
+    try:
+        data = request.get_json() or {}
+        name = data.get("name")
+        price = data.get("price", 0)
+        features = data.get("features", {})
+
+        if not name:
+            return jsonify({"error": "Plan adı gereklidir."}), 400
+
+        plan = Plan(name=name, price=price, features=json.dumps(features))
+        db.session.add(plan)
+        db.session.commit()
+
+        return jsonify(
+            {
+                "success": True,
+                "plan": {
+                    "id": plan.id,
+                    "name": plan.name,
+                    "features": features,
+                },
+            }
+        )
+    except Exception as e:  # pragma: no cover - unexpected errors
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 500
+
+
+@plan_admin_limits_bp.route("/<int:plan_id>/delete", methods=["DELETE"])
+@jwt_required()
+@require_csrf
+@require_admin
+def delete_plan(plan_id):
+    """Delete a plan by its id."""
+    try:
+        plan = Plan.query.get(plan_id)
+        if not plan:
+            return jsonify({"error": "Plan bulunamadı."}), 404
+
+        db.session.delete(plan)
+        db.session.commit()
+        return jsonify({"success": True, "message": "Plan silindi."})
+    except Exception as e:  # pragma: no cover - unexpected errors
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary
- add plan create & delete routes in admin limits API
- test create and delete plan endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688147308b30832fa17989449ee61ec6