### PR TITLE
Add end-to-end plan create/delete test

### DIFF
--- a/backend/api/plan_admin_limits.py
+++ b/backend/api/plan_admin_limits.py
@@ -93,16 +93,7 @@ def create_plan():
         db.session.add(plan)
         db.session.commit()
 
-        return jsonify(
-            {
-                "success": True,
-                "plan": {
-                    "id": plan.id,
-                    "name": plan.name,
-                    "features": features,
-                },
-            }
-        )
+        return jsonify(plan.to_dict()), 201
     except Exception as e:
         db.session.rollback()
         return jsonify({"error": str(e)}), 500

--- a/tests/test_plan_admin_limits.py
+++ b/tests/test_plan_admin_limits.py
@@ -136,17 +136,43 @@ def test_get_all_plans(admin_app):
     assert len(data) == 2
 
 
+def test_create_and_delete_plan(admin_app):
+    client = admin_app.test_client()
+
+    payload = {
+        "name": "enterprise",
+        "price": 99.99,
+        "features": {
+            "predict": 1000,
+            "reports": 50,
+        },
+    }
+
+    create_resp = client.post("/api/plans/create", json=payload)
+    assert create_resp.status_code == 201
+    created = create_resp.get_json()
+    assert created["name"] == "enterprise"
+    assert created["features"]["predict"] == 1000
+
+    plan_id = created["id"]
+
+    delete_resp = client.delete(f"/api/plans/{plan_id}")
+    assert delete_resp.status_code == 200
+    delete_data = delete_resp.get_json()
+    assert delete_data["success"] is True
+    assert "silindi" in delete_data["message"]
+
+
 def test_create_plan_success(admin_app):
     client = admin_app.test_client()
     resp = client.post(
         "/api/plans/create",
         json={"name": "new", "price": 5.0, "features": {"predict": 3}},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 201
     data = resp.get_json()
-    assert data["success"] is True
-    assert data["plan"]["name"] == "new"
-    assert data["plan"]["features"]["predict"] == 3
+    assert data["name"] == "new"
+    assert data["features"]["predict"] == 3
 
     with admin_app.app_context():
         created = Plan.query.filter_by(name="new").first()


### PR DESCRIPTION
## Summary
- verify plan creation and deletion with new test
- make create plan endpoint return plan dict with HTTP 201
- adapt existing admin plan tests for new response format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881eeaed098832f96fd45501526150f