### PR TITLE
Add AdminPlanManager component

### DIFF
--- a/frontend/react/AdminPlanManager.tsx
+++ b/frontend/react/AdminPlanManager.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import { Card, CardBody, Button, Input, Spinner, Alert } from 'reactstrap';
+import { toast } from 'sonner';
+import useAdminPlans from './hooks/useAdminPlans';
+import { NewPlan } from './types';
+
+export default function AdminPlanManager() {
+  const { plans, setPlans, loading, error, load, saveAll, addPlan, removePlan } =
+    useAdminPlans();
+  const [saving, setSaving] = useState(false);
+  const [newPlan, setNewPlan] = useState<NewPlan>({
+    name: '',
+    price: 0,
+    features: { predict: 0 },
+  });
+
+  const handleInputChange = (
+    planId: number,
+    key: string,
+    value: string | number
+  ) => {
+    setPlans((prev) =>
+      prev.map((p) =>
+        p.id === planId
+          ? { ...p, features: { ...p.features, [key]: Number(value) } }
+          : p
+      )
+    );
+  };
+
+  const handleSaveAll = async () => {
+    setSaving(true);
+    try {
+      await saveAll();
+      toast.success('Tüm limitler güncellendi.');
+    } catch {
+      toast.error('Güncelleme sırasında hata oluştu.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleNewPlanChange = (key: string, value: string) => {
+    if (key.startsWith('features.')) {
+      const featureKey = key.split('.')[1];
+      setNewPlan((prev) => ({
+        ...prev,
+        features: { ...prev.features, [featureKey]: parseInt(value) || 0 },
+      }));
+    } else {
+      setNewPlan((prev) => ({ ...prev, [key]: value }));
+    }
+  };
+
+  const handleCreatePlan = async () => {
+    try {
+      const created = await addPlan(newPlan);
+      toast.success(`${created.name} başarıyla oluşturuldu.`);
+      setNewPlan({ name: '', price: 0, features: { predict: 0 } });
+    } catch {
+      toast.error('Plan oluşturulamadı.');
+    }
+  };
+
+  const handleDeletePlan = async (planId: number) => {
+    try {
+      await removePlan(planId);
+      toast.success('Plan silindi.');
+    } catch {
+      toast.error('Plan silinemedi.');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="d-flex align-items-center">
+        <Spinner size="sm" className="me-2" /> Yükleniyor...
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Plan Yönetimi</h2>
+      {error && <Alert color="danger">{error}</Alert>}
+
+      <div className="row">
+        {plans.map((plan) => (
+          <Card key={plan.id} className="col-md-4 mb-4">
+            <CardBody>
+              <h5>
+                {plan.name}{' '}
+                <Button
+                  size="sm"
+                  color="danger"
+                  onClick={() => handleDeletePlan(plan.id)}
+                >
+                  Sil
+                </Button>
+              </h5>
+              {Object.entries(plan.features).map(([key, value]) => (
+                <div key={key} className="mb-2">
+                  <label>{key}</label>
+                  <Input
+                    type="number"
+                    value={value}
+                    onChange={(e) =>
+                      handleInputChange(plan.id, key, e.target.value)
+                    }
+                  />
+                </div>
+              ))}
+            </CardBody>
+          </Card>
+        ))}
+      </div>
+
+      <Button
+        onClick={handleSaveAll}
+        disabled={saving}
+        color="primary"
+        className="mb-4"
+      >
+        {saving ? 'Kaydediliyor...' : 'Tümünü Kaydet'}
+      </Button>
+
+      <h4>Yeni Plan Oluştur</h4>
+      <div className="row">
+        <div className="col-md-3">
+          <Input
+            placeholder="Plan Adı"
+            value={newPlan.name}
+            onChange={(e) => handleNewPlanChange('name', e.target.value)}
+          />
+        </div>
+        <div className="col-md-2">
+          <Input
+            type="number"
+            placeholder="Fiyat"
+            value={newPlan.price}
+            onChange={(e) => handleNewPlanChange('price', e.target.value)}
+          />
+        </div>
+        <div className="col-md-2">
+          <Input
+            type="number"
+            placeholder="predict"
+            value={newPlan.features.predict}
+            onChange={(e) =>
+              handleNewPlanChange('features.predict', e.target.value)
+            }
+          />
+        </div>
+        <div className="col-md-2">
+          <Button onClick={handleCreatePlan}>Oluştur</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/react/api.ts
+++ b/frontend/react/api.ts
@@ -1,0 +1,36 @@
+import { Plan, NewPlan } from './types';
+
+async function handleResponse(res: Response) {
+  if (!res.ok) {
+    throw new Error('Request failed');
+  }
+  return res.json();
+}
+
+export async function fetchPlans(): Promise<Plan[]> {
+  const res = await fetch('/api/plans/all');
+  return handleResponse(res);
+}
+
+export async function updatePlanLimits(planId: number, features: Record<string, number>) {
+  const res = await fetch(`/api/plans/${planId}/update-limits`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(features),
+  });
+  return handleResponse(res);
+}
+
+export async function createPlan(plan: NewPlan): Promise<Plan> {
+  const res = await fetch('/api/plans/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(plan),
+  });
+  return handleResponse(res);
+}
+
+export async function deletePlan(planId: number) {
+  const res = await fetch(`/api/plans/${planId}`, { method: 'DELETE' });
+  return handleResponse(res);
+}

--- a/frontend/react/hooks/useAdminPlans.ts
+++ b/frontend/react/hooks/useAdminPlans.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { fetchPlans, updatePlanLimits, createPlan, deletePlan } from '../api';
+import { Plan, NewPlan } from '../types';
+
+export default function useAdminPlans() {
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchPlans();
+      setPlans(data);
+    } catch {
+      setError('Planlar yüklenemedi.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const saveAll = async () => {
+    for (const plan of plans) {
+      await updatePlanLimits(plan.id, plan.features);
+    }
+  };
+
+  const addPlan = async (plan: NewPlan) => {
+    const created = await createPlan(plan);
+    setPlans((prev) => [...prev, created]);
+    return created;
+  };
+
+  const removePlan = async (planId: number) => {
+    await deletePlan(planId);
+    setPlans((prev) => prev.filter((p) => p.id !== planId));
+  };
+
+  return { plans, setPlans, loading, error, load, saveAll, addPlan, removePlan };
+}

--- a/frontend/react/types.ts
+++ b/frontend/react/types.ts
@@ -1,0 +1,12 @@
+export interface Plan {
+  id: number;
+  name: string;
+  price: number;
+  features: Record<string, number>;
+}
+
+export interface NewPlan {
+  name: string;
+  price: number;
+  features: Record<string, number>;
+}

--- a/frontend/tests/AdminPlanManager.test.tsx
+++ b/frontend/tests/AdminPlanManager.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import AdminPlanManager from '../react/AdminPlanManager';
+
+jest.mock('reactstrap', () => ({
+  Card: (p: any) => <div {...p} />,
+  CardBody: (p: any) => <div {...p} />,
+  Button: (p: any) => <button {...p} />,
+  Input: (p: any) => <input {...p} />,
+  Spinner: (p: any) => <div {...p} />,
+  Alert: (p: any) => <div {...p} />,
+}));
+jest.mock('../react/api', () => ({
+  fetchPlans: jest.fn(() =>
+    Promise.resolve([{ id: 1, name: 'Basic', price: 0, features: { predict: 1 } }])
+  ),
+  updatePlanLimits: jest.fn(() => Promise.resolve({})),
+  createPlan: jest.fn((p) => Promise.resolve({ ...p, id: 2 })),
+  deletePlan: jest.fn(() => Promise.resolve({})),
+}));
+
+test('loads and displays plans', async () => {
+  render(<AdminPlanManager />);
+  expect(await screen.findByText('Basic')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add a reusable API helper for admin plan actions
- create `useAdminPlans` hook to fetch/manage plans
- implement `AdminPlanManager` component using the hook
- provide TypeScript plan types
- test rendering of the new component

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882227c1374832fb1999552cc288a27