### PR TITLE
Add admin plan management test

### DIFF
--- a/tests/test_admin_plan_management.py
+++ b/tests/test_admin_plan_management.py
@@ -1,0 +1,60 @@
+import json
+import pytest
+from backend import create_app, db
+from backend.models.plan import Plan
+from backend.auth import jwt_utils
+import flask_jwt_extended
+
+@pytest.fixture
+def admin_client(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setattr(flask_jwt_extended, "jwt_required", lambda *a, **k: (lambda f: f))
+    monkeypatch.setattr("backend.auth.jwt_utils.require_admin", lambda f: f)
+    monkeypatch.setattr("backend.auth.jwt_utils.require_csrf", lambda f: f)
+
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.app_context():
+        db.create_all()
+        yield app.test_client()
+        db.drop_all()
+
+
+def test_full_plan_crud_flow(admin_client):
+    # CREATE
+    payload = {
+        "name": "gold",
+        "price": 29.99,
+        "features": {"predict": 200, "analytics": 50},
+    }
+    resp_create = admin_client.post("/api/plans/create", json=payload)
+    assert resp_create.status_code == 201
+    created = resp_create.get_json()
+    assert created["name"] == "gold"
+    assert created["features"]["predict"] == 200
+    pid = created["id"]
+
+    # UPDATE
+    update_payload = {"predict": 500, "analytics": 100}
+    resp_update = admin_client.post(f"/api/plans/{pid}/update-limits", json=update_payload)
+    assert resp_update.status_code == 200
+    updated = resp_update.get_json()
+    assert updated["plan"]["features"]["predict"] == 500
+
+    # GET ALL
+    resp_all = admin_client.get("/api/plans/all")
+    assert resp_all.status_code == 200
+    plans = resp_all.get_json()
+    assert any(p["name"] == "gold" for p in plans)
+
+    # DELETE
+    resp_delete = admin_client.delete(f"/api/plans/{pid}")
+    assert resp_delete.status_code == 200
+    deleted = resp_delete.get_json()
+    assert deleted["success"] is True
+
+    # CONFIRM DELETE
+    resp_check = admin_client.get("/api/plans/all")
+    plans_after = resp_check.get_json()
+    assert not any(p["id"] == pid for p in plans_after)


### PR DESCRIPTION
## Summary
- add new `test_admin_plan_management.py` verifying CRUD flow for `/api/plans`

## Testing
- `pytest tests/test_admin_plan_management.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882267361d4832fbb089394be631154