### PR TITLE
Add admin plan route components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "lucide-react": "^0.525.0",
     "reactstrap": "^9.2.3",
-    "sonner": "^2.0.6"
+    "sonner": "^2.0.6",
+    "react-router-dom": "^6.23.0"
   }
 }

--- a/frontend/react/AdminRoutes.tsx
+++ b/frontend/react/AdminRoutes.tsx
@@ -1,0 +1,21 @@
+import { Route, Routes } from 'react-router-dom';
+import AdminPlanManager from './AdminPlanManager';
+import { ProtectedRoute } from './ProtectedRoute';
+
+function AdminRoutes() {
+  return (
+    <Routes>
+      {/* Diğer admin route'ları */}
+      <Route
+        path="/admin/plans"
+        element={
+          <ProtectedRoute isAdmin={true}>
+            <AdminPlanManager />
+          </ProtectedRoute>
+        }
+      />
+    </Routes>
+  );
+}
+
+export default AdminRoutes;

--- a/frontend/react/ProtectedRoute.tsx
+++ b/frontend/react/ProtectedRoute.tsx
@@ -1,0 +1,8 @@
+import { Navigate } from 'react-router-dom';
+
+export function ProtectedRoute({ isAdmin, children }: { isAdmin: boolean; children: JSX.Element }) {
+  if (!isAdmin) {
+    return <Navigate to="/unauthorized" />;
+  }
+  return children;
+}

--- a/frontend/react/components/AdminSidebar.tsx
+++ b/frontend/react/components/AdminSidebar.tsx
@@ -1,0 +1,18 @@
+import { NavLink } from 'react-router-dom';
+
+function AdminSidebar() {
+  return (
+    <div className="sidebar">
+      <ul>
+        {/* Diğer menü öğeleri */}
+        <li>
+          <NavLink to="/admin/plans" className={({ isActive }) => (isActive ? 'active' : undefined)}>
+            Plan Yönetimi
+          </NavLink>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+export default AdminSidebar;


### PR DESCRIPTION
## Summary
- add AdminSidebar with link to Plan Yönetimi page
- add ProtectedRoute wrapper
- register `/admin/plans` in AdminRoutes
- include `react-router-dom` in dependencies

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68822a3d4d18832fb22d11f1e3b1d87d