### PR TITLE
Implement admin guard helper

### DIFF
--- a/frontend/react/auth/AuthContext.tsx
+++ b/frontend/react/auth/AuthContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+interface AuthUser {
+  id: number;
+  username: string;
+  is_admin: boolean;
+}
+
+interface AuthContextState {
+  user: AuthUser | null;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextState>({ user: null, loading: true });
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // In a real app, fetch the current user from an API or storage
+    const stored = localStorage.getItem('user');
+    if (stored) {
+      try {
+        setUser(JSON.parse(stored));
+      } catch {
+        setUser(null);
+      }
+    }
+    setLoading(false);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/frontend/react/utils/withAdminGuard.tsx
+++ b/frontend/react/utils/withAdminGuard.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../auth/AuthContext';
+
+export default function withAdminGuard<P>(Component: React.ComponentType<P>) {
+  return function GuardedComponent(props: P) {
+    const { user, loading } = useAuth();
+
+    if (loading) {
+      return <div>Yükleniyor...</div>;
+    }
+
+    if (!user || !user.is_admin) {
+      return <Navigate to="/unauthorized" replace />;
+    }
+
+    return <Component {...props} />;
+  };
+}

--- a/frontend/tests/AdminPlanManager.test.tsx
+++ b/frontend/tests/AdminPlanManager.test.tsx
@@ -10,6 +10,9 @@ jest.mock('reactstrap', () => ({
   Input: (p: any) => <input {...p} />,
   Spinner: (p: any) => <div {...p} />,
   Alert: (p: any) => <div {...p} />,
+  Modal: (p: any) => <div {...p} />,
+  ModalBody: (p: any) => <div {...p} />,
+  ModalFooter: (p: any) => <div {...p} />,
 }));
 jest.mock('../react/api', () => ({
   fetchPlans: jest.fn(() =>


### PR DESCRIPTION
## Summary
- add a small AuthContext for React components
- create `withAdminGuard` HOC with proper typings
- extend AdminPlanManager test mocks to cover modal components

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6883a7545bd8832f9cc1283431943747