### PR TITLE
Add admin dashboard component with protected plan management

### DIFF
--- a/frontend/react/AdminDashboard.tsx
+++ b/frontend/react/AdminDashboard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Container, Nav, NavItem, NavLink, TabContent, TabPane } from 'reactstrap';
+import { useState } from 'react';
+import { ProtectedAdminPlanManager } from './AdminPlanManager';
+
+// Diğer admin bileşenleri import edilebilir (ör: UserManagement, LogsPanel vs.)
+
+export default function AdminDashboard() {
+  const [activeTab, setActiveTab] = useState('plans');
+
+  return (
+    <Container className="mt-4">
+      <h2>Admin Panel</h2>
+      <Nav tabs>
+        <NavItem>
+          <NavLink
+            className={activeTab === 'plans' ? 'active' : ''}
+            onClick={() => setActiveTab('plans')}
+          >
+            Plan Yönetimi
+          </NavLink>
+        </NavItem>
+        {/* Diğer sekmeler */}
+      </Nav>
+
+      <TabContent activeTab={activeTab} className="mt-3">
+        <TabPane tabId="plans">
+          <ProtectedAdminPlanManager />
+        </TabPane>
+        {/* Diğer tabpanes */}
+      </TabContent>
+    </Container>
+  );
+}

--- a/frontend/react/AdminPlanManager.tsx
+++ b/frontend/react/AdminPlanManager.tsx
@@ -14,6 +14,7 @@ import { toast } from 'sonner';
 import useAdminPlans from './hooks/useAdminPlans';
 import { NewPlan } from './types';
 import { Trash2, Plus, Save, XCircle } from 'lucide-react';
+import { ProtectedRoute } from './ProtectedRoute';
 
 export default function AdminPlanManager() {
   const { plans, setPlans, loading, error, load, saveAll, addPlan, removePlan } =
@@ -250,5 +251,13 @@ export default function AdminPlanManager() {
         </div>
       </div>
     </div>
+  );
+}
+
+export function ProtectedAdminPlanManager() {
+  return (
+    <ProtectedRoute isAdmin={true}>
+      <AdminPlanManager />
+    </ProtectedRoute>
   );
 }


### PR DESCRIPTION
## Summary
- implement `ProtectedAdminPlanManager` export
- create new `AdminDashboard` React page that uses it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a87b0618832fa128402e1209f7bc