### PR TITLE
Add simple user management tab

### DIFF
--- a/frontend/react/AdminDashboard.tsx
+++ b/frontend/react/AdminDashboard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Container, Nav, NavItem, NavLink, TabContent, TabPane } from 'reactstrap';
 import { useState } from 'react';
 import { ProtectedAdminPlanManager } from './AdminPlanManager';
+import UserManagement from './UserManagement';
 
 // Diğer admin bileşenleri import edilebilir (ör: UserManagement, LogsPanel vs.)
 
@@ -20,12 +21,22 @@ export default function AdminDashboard() {
             Plan Yönetimi
           </NavLink>
         </NavItem>
-        {/* Diğer sekmeler */}
+        <NavItem>
+          <NavLink
+            className={activeTab === 'users' ? 'active' : ''}
+            onClick={() => setActiveTab('users')}
+          >
+            Kullanıcı Yönetimi
+          </NavLink>
+        </NavItem>
       </Nav>
 
       <TabContent activeTab={activeTab} className="mt-3">
         <TabPane tabId="plans">
           <ProtectedAdminPlanManager />
+        </TabPane>
+        <TabPane tabId="users">
+          <UserManagement />
         </TabPane>
         {/* Diğer tabpanes */}
       </TabContent>

--- a/frontend/react/AdminPlanManager.tsx
+++ b/frontend/react/AdminPlanManager.tsx
@@ -257,6 +257,6 @@ export default function AdminPlanManager() {
   );
 }
 
-\nexport const ProtectedAdminPlanManager = withAdminGuard(AdminPlanManager);
+export const ProtectedAdminPlanManager = withAdminGuard(AdminPlanManager);
 
 

--- a/frontend/react/UserManagement.tsx
+++ b/frontend/react/UserManagement.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function UserManagement() {
+  return <div>User Management Content</div>;
+}


### PR DESCRIPTION
## Summary
- add placeholder `UserManagement` component
- integrate a new Users tab in `AdminDashboard`
- fix syntax in `AdminPlanManager` that broke Jest

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d274d8c8832f92c4d72b4451c7d5