### PR TITLE
Implement optional JWT for testing

### DIFF
--- a/backend/api/plan_admin_limits.py
+++ b/backend/api/plan_admin_limits.py
@@ -1,6 +1,5 @@
 from flask import Blueprint, request, jsonify
-from flask_jwt_extended import jwt_required
-from backend.auth.jwt_utils import require_csrf, require_admin
+from backend.auth.jwt_utils import require_csrf, require_admin, optional_jwt_required
 from backend import db
 from backend.models.plan import Plan
 import json
@@ -13,7 +12,7 @@ plan_admin_limits_bp = Blueprint(
 
 
 @plan_admin_limits_bp.route("/<int:plan_id>/update-limits", methods=["POST"])
-@jwt_required()
+@optional_jwt_required()
 @require_csrf
 @require_admin
 def update_plan_limits(plan_id):
@@ -53,7 +52,7 @@ def update_plan_limits(plan_id):
 
 
 @plan_admin_limits_bp.route("/all", methods=["GET"])
-@jwt_required()
+@optional_jwt_required()
 @require_csrf
 @require_admin
 def get_all_plans():
@@ -73,7 +72,7 @@ def get_all_plans():
 
 
 @plan_admin_limits_bp.route("/create", methods=["POST"])
-@jwt_required()
+@optional_jwt_required()
 @require_csrf
 @require_admin
 def create_plan():
@@ -89,6 +88,10 @@ def create_plan():
         if not name or not isinstance(features, dict):
             return jsonify({"error": "Geçersiz plan verileri"}), 400
 
+        for key, val in features.items():
+            if not isinstance(val, int) or val < 0:
+                return jsonify({"error": f"'{key}' için geçersiz limit değeri."}), 400
+
         plan = Plan(name=name, price=price, features=json.dumps(features))
         db.session.add(plan)
         db.session.commit()
@@ -100,7 +103,7 @@ def create_plan():
 
 
 @plan_admin_limits_bp.route("/<int:plan_id>", methods=["DELETE"])
-@jwt_required()
+@optional_jwt_required()
 @require_csrf
 @require_admin
 def delete_plan(plan_id):

--- a/backend/auth/jwt_utils.py
+++ b/backend/auth/jwt_utils.py
@@ -3,6 +3,8 @@
 
 import jwt
 import secrets
+import os
+from flask_jwt_extended import jwt_required
 from datetime import datetime, timedelta
 from flask import current_app, request, abort, jsonify
 import logging
@@ -150,4 +152,13 @@ def require_admin(func):
             return jsonify({"error": "Sunucu hatası."}), 500
 
     return wrapper
+
+
+def optional_jwt_required():
+    """Return a no-op decorator when testing, else flask_jwt_extended.jwt_required."""
+    if os.getenv("FLASK_ENV") == "testing":
+        def decorator(fn):
+            return fn
+        return decorator
+    return jwt_required()
 


### PR DESCRIPTION
## Summary
- add `optional_jwt_required` helper that bypasses `jwt_required` when `FLASK_ENV=testing`
- validate feature limits when creating plans
- apply the new helper in plan admin routes

## Testing
- `pytest -q /tmp/snippet_test.py -vv --rootdir=/workspace/ytd-kopya`
- `pytest -q` *(fails: tests expect JWT auth to reject unauthenticated requests)*

------
https://chatgpt.com/codex/tasks/task_e_6883dde21220832fa34eb2ff1e34476c