### PR TITLE
Fix admin plan auth test

### DIFF
--- a/backend/api/plan_admin_limits.py
+++ b/backend/api/plan_admin_limits.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, request, jsonify
-from backend.auth.jwt_utils import require_csrf, require_admin, optional_jwt_required
+from backend.auth.jwt_utils import require_csrf, require_admin
+from flask_jwt_extended import jwt_required
 from backend import db
 from backend.models.plan import Plan
 import json
@@ -12,7 +13,7 @@ plan_admin_limits_bp = Blueprint(
 
 
 @plan_admin_limits_bp.route("/<int:plan_id>/update-limits", methods=["POST"])
-@optional_jwt_required()
+@jwt_required()
 @require_csrf
 @require_admin
 def update_plan_limits(plan_id):
@@ -52,7 +53,7 @@ def update_plan_limits(plan_id):
 
 
 @plan_admin_limits_bp.route("/all", methods=["GET"])
-@optional_jwt_required()
+@jwt_required()
 @require_csrf
 @require_admin
 def get_all_plans():
@@ -72,7 +73,7 @@ def get_all_plans():
 
 
 @plan_admin_limits_bp.route("/create", methods=["POST"])
-@optional_jwt_required()
+@jwt_required()
 @require_csrf
 @require_admin
 def create_plan():
@@ -103,7 +104,7 @@ def create_plan():
 
 
 @plan_admin_limits_bp.route("/<int:plan_id>", methods=["DELETE"])
-@optional_jwt_required()
+@jwt_required()
 @require_csrf
 @require_admin
 def delete_plan(plan_id):


### PR DESCRIPTION
## Summary
- make admin plan endpoints require JWT tokens

## Testing
- `pytest tests/test_admin_plan_management.py::test_create_plan_unauthorized -q`


------
https://chatgpt.com/codex/tasks/task_e_6883e2bcc590832fa2626a3b2bf3d7f6