### PR TITLE
Add decision maker to scoring engine

### DIFF
--- a/backend/decision_engine/__init__.py
+++ b/backend/decision_engine/__init__.py
@@ -1,5 +1,6 @@
 """Utilities for lightweight feature extraction."""
 
 from .feature_extraction import extract_features
+from .decision_maker import make_decision
 
-__all__ = ["extract_features"]
+__all__ = ["extract_features", "make_decision"]

--- a/backend/decision_engine/decision_maker.py
+++ b/backend/decision_engine/decision_maker.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+
+
+def make_decision(coin: str, score: float) -> dict:
+    """Skora gore karar ve aciklama uretir."""
+    if score >= 75:
+        recommendation = "AL"
+        explanation = "Teknik gostergeler guclu alim sinyali veriyor."
+        expected_return = 0.25
+        confidence = 90
+    elif score >= 50:
+        recommendation = "TUT"
+        explanation = "Belirsizlik var, gozlemlemeye devam edin."
+        expected_return = 0.10
+        confidence = 70
+    else:
+        recommendation = "SAT"
+        explanation = "Dusus sinyalleri agir basiyor, riskli bolge."
+        expected_return = -0.15
+        confidence = 60
+
+    return {
+        "coin": coin,
+        "score": round(score, 2),
+        "recommendation": recommendation,
+        "confidence": confidence,
+        "expected_return": expected_return,
+        "valid_until": (datetime.utcnow() + timedelta(days=7)).isoformat(),
+        "explanation": explanation,
+    }


### PR DESCRIPTION
## Summary
- introduce `decision_maker.py` for scoring-based decisions
- expose `make_decision` in `decision_engine` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a9071a40832f9b25501bb8ad34d8