### PR TITLE
Add decision evaluation API

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -250,6 +250,7 @@ def create_app():
     from backend.api.ta_routes import bp as ta_bp
     from backend.api.public.technical import technical_bp
     from backend.api.public.subscriptions import subscriptions_bp
+    from backend.api.decision import decision_bp
 
     # APScheduler tabanli gorevleri istege bagli olarak baslat
     if os.getenv("ENABLE_SCHEDULER", "0") == "1":
@@ -275,6 +276,7 @@ def create_app():
     app.register_blueprint(ta_bp)
     app.register_blueprint(technical_bp)
     app.register_blueprint(subscriptions_bp)
+    app.register_blueprint(decision_bp)
     app.register_blueprint(limits_bp)
 
     # Sağlık Kontrol Endpoint'i

--- a/backend/api/decision.py
+++ b/backend/api/decision.py
@@ -1,0 +1,31 @@
+from flask import Blueprint, request, jsonify
+
+from backend.decision_engine import extract_features
+from backend.decision_engine.score_calculator import calculate_score
+from backend.engine.strategic_decision_engine import advanced_decision_logic
+
+# Blueprint for lightweight decision endpoints
+decision_bp = Blueprint('decision', __name__, url_prefix='/api/decision')
+
+
+@decision_bp.route('/evaluate', methods=['POST'])
+def evaluate_decision():
+    """Return decision signal and weighted score for provided indicators."""
+    data = request.get_json() or {}
+
+    # Extract normalized features and calculate weighted score
+    features = extract_features(data)
+    score = calculate_score(features)
+
+    # Map data to inputs expected by advanced_decision_logic
+    indicators = {
+        'rsi': data.get('rsi'),
+        'macd': data.get('macd'),
+        'macd_signal': data.get('macd_signal'),
+        'price': data.get('price'),
+        'sma_10': data.get('sma_10'),
+        'prev_predictions_success_rate': data.get('prev_predictions_success_rate', 0),
+    }
+    decision = advanced_decision_logic(indicators)
+
+    return jsonify({'decision': decision, 'score': score, 'features': features})


### PR DESCRIPTION
## Summary
- introduce new `decision_bp` blueprint with evaluation endpoint
- register `decision_bp` in `create_app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a9ad6340832f97a6719e2dfe0c4c