### PR TITLE
Add decision blueprint predict endpoint test

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -277,7 +277,6 @@ def create_app():
     app.register_blueprint(technical_bp)
     app.register_blueprint(decision_bp)
     app.register_blueprint(subscriptions_bp)
-    app.register_blueprint(decision_bp)
     app.register_blueprint(limits_bp)
 
     # Sağlık Kontrol Endpoint'i

--- a/backend/api/decision.py
+++ b/backend/api/decision.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, jsonify
 
-from backend.decision_engine import extract_features
+from backend.decision_engine import extract_features, make_decision
 from backend.decision_engine.score_calculator import calculate_score
 from backend.engine.strategic_decision_engine import advanced_decision_logic
 
@@ -29,3 +29,17 @@ def evaluate_decision():
     decision = advanced_decision_logic(indicators)
 
     return jsonify({'decision': decision, 'score': score, 'features': features})
+
+
+@decision_bp.route('/predict', methods=['POST'])
+def predict_decision():
+    """Return a recommendation based on provided market indicators."""
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid JSON"}), 400
+
+    features = extract_features(data)
+    score = calculate_score(features)
+    coin = data.get("coin", "UNKNOWN")
+    result = make_decision(coin, score)
+    return jsonify(result)

--- a/backend/tests/test_decision.py
+++ b/backend/tests/test_decision.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pytest
+from flask import Flask
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+from backend.api.decision import decision_bp
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(decision_bp)
+    app.testing = True
+    return app.test_client()
+
+def test_predict_decision_success(client):
+    response = client.post("/api/decision/predict", json={
+        "coin": "BTC",
+        "rsi": 45,
+        "macd": 1.2,
+        "macd_signal": 0.9,
+        "sma_7": 105,
+        "sma_30": 100,
+        "prev_success_rate": 0.7,
+        "sentiment_score": 0.2,
+        "news_count": 10
+    })
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "recommendation" in data
+    assert "score" in data
+    assert data["coin"] == "BTC"
+
+def test_predict_decision_invalid_json(client):
+    response = client.post("/api/decision/predict", data="invalid json", content_type="application/json")
+    assert response.status_code == 400
+    assert "error" in response.get_json()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 minversion = 6.0
 addopts = -ra --cov=backend --cov-report=term-missing
-testpaths = tests
+testpaths = tests backend/tests


### PR DESCRIPTION
## Summary
- add new decision API `/predict` for returning recommendations
- add unit tests for the new endpoint
- include new backend tests path in pytest configuration
- fix duplicate blueprint registration

## Testing
- `pytest backend/tests/test_decision.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ad1df094832fa50353ef90b3d3af