### PR TITLE
Fix Plan limit editor types and tests

### DIFF
--- a/frontend/react/AdminPlanLimitEditor.tsx
+++ b/frontend/react/AdminPlanLimitEditor.tsx
@@ -28,11 +28,17 @@ export default function AdminPlanLimitEditor() {
   };
 
   const handleInputChange = (planId: number, key: string, value: string) => {
-    setPlans((prevPlans) =>
-      prevPlans.map((plan) =>
-        plan.id === planId ? { ...plan, features: { ...plan.features, [key]: value } } : plan
-      )
-    );
+    setPlans((prevPlans: Plan[]) => {
+      const updated = prevPlans.map((plan) =>
+        plan.id === planId
+          ? {
+              ...plan,
+              features: { ...plan.features, [key]: Number(value) } as Record<string, number>,
+            }
+          : plan
+      );
+      return updated;
+    });
   };
 
   const handleSave = async () => {

--- a/frontend/react/AdminRoutes.tsx
+++ b/frontend/react/AdminRoutes.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import AdminPlanManager from './AdminPlanManager';
 import { ProtectedRoute } from './ProtectedRoute';

--- a/frontend/react/ProtectedRoute.tsx
+++ b/frontend/react/ProtectedRoute.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 
 export function ProtectedRoute({ isAdmin, children }: { isAdmin: boolean; children: JSX.Element }) {

--- a/frontend/react/components/AdminSidebar.tsx
+++ b/frontend/react/components/AdminSidebar.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { NavLink } from 'react-router-dom';
 
 function AdminSidebar() {

--- a/frontend/tests/PlanLimitCard.test.tsx
+++ b/frontend/tests/PlanLimitCard.test.tsx
@@ -4,11 +4,14 @@ import '@testing-library/jest-dom';
 import PlanLimitCard from '../react/PlanLimitCard';
 import { toast } from 'sonner';
 
+type ExtendedMock = jest.Mock & { error?: jest.Mock; warning?: jest.Mock };
+var mockFn: ExtendedMock;
+
 jest.mock('sonner', () => {
-  const fn = jest.fn();
-  fn.error = jest.fn();
-  fn.warning = jest.fn();
-  return { toast: fn };
+  mockFn = jest.fn() as ExtendedMock;
+  mockFn.error = jest.fn();
+  mockFn.warning = jest.fn();
+  return { toast: mockFn };
 });
 
 beforeEach(() => {
@@ -42,7 +45,7 @@ test('triggers warning toast at 90 percent usage', async () => {
   );
   render(<PlanLimitCard />);
   await screen.findByText('Kullanım: 9 / 10');
-  expect((toast as any).warning).toHaveBeenCalled();
+  expect(mockFn.warning).toHaveBeenCalled();
 });
 
 test('triggers error toast at full usage', async () => {
@@ -57,5 +60,5 @@ test('triggers error toast at full usage', async () => {
   );
   render(<PlanLimitCard />);
   await screen.findByText('Kullanım: 10 / 10');
-  expect((toast as any).error).toHaveBeenCalled();
+  expect(mockFn.error).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- add missing React imports in admin components
- ensure AdminPlanLimitEditor parses inputs as numbers
- improve toast mock typings in PlanLimitCard tests

## Testing
- `npm run build --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6885077d6480832f87ce955049552cd3