### PR TITLE
Fix CI to build frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
           files: ./coverage.xml
 
       - name: Install frontend dependencies
-        working-directory: ./frontend
         run: |
+          cd frontend
           npm install
 
-      - name: Run frontend build
-        working-directory: ./frontend
+      - name: Build frontend
         run: |
+          cd frontend
           npm run build
 
       - name: Run frontend type check


### PR DESCRIPTION
## Summary
- run `npm install` with `cd frontend`
- build the frontend before tests

## Testing
- `pip install -r requirements.txt` *(fails: torch==2.1.0 not available for Python 3.11)*
- `pytest -k none` *(fails: ModuleNotFoundError: flask)*


------
https://chatgpt.com/codex/tasks/task_e_688513431164832f812251264c4915de