### PR TITLE
Implement AdminLogs page and React imports

### DIFF
--- a/frontend/react/AdminRoutes.tsx
+++ b/frontend/react/AdminRoutes.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import AdminDashboard from './pages/AdminDashboard';
 import AdminUsers from './pages/AdminUsers';

--- a/frontend/react/components/AdminSidebar.tsx
+++ b/frontend/react/components/AdminSidebar.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { NavLink } from 'react-router-dom';
 
 const AdminSidebar = () => {

--- a/frontend/react/pages/AdminLogs.tsx
+++ b/frontend/react/pages/AdminLogs.tsx
@@ -1,1 +1,11 @@
+import React from 'react';
 
+const AdminLogs: React.FC = () => {
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold">Log Kayıtları</h1>
+    </div>
+  );
+};
+
+export default AdminLogs;


### PR DESCRIPTION
## Summary
- add missing React imports in Admin sidebar and admin routes
- implement `AdminLogs` page
- ensure route to logs page is exposed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf405d620832f9599f5b5cd9c2703