### PR TITLE
Add logging model and admin page

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -246,6 +246,7 @@ def create_app():
     from backend.api.admin.backup import backup_bp
     from backend.api.admin.system_events import events_bp
     from backend.api.admin.analytics import analytics_bp
+    from backend.api.logs import logs_bp
     from backend.limits.routes import limits_bp
     from backend.api.ta_routes import bp as ta_bp
     from backend.api.public.technical import technical_bp
@@ -273,6 +274,7 @@ def create_app():
     app.register_blueprint(backup_bp)
     app.register_blueprint(events_bp)
     app.register_blueprint(analytics_bp)
+    app.register_blueprint(logs_bp)
     app.register_blueprint(ta_bp)
     app.register_blueprint(technical_bp)
     app.register_blueprint(decision_bp)

--- a/backend/api/logs.py
+++ b/backend/api/logs.py
@@ -1,0 +1,36 @@
+from flask import Blueprint, request, jsonify
+
+from backend.models.log import Log
+
+
+logs_bp = Blueprint("logs", __name__, url_prefix="/api/admin/logs")
+
+
+@logs_bp.route("", methods=["GET"])
+def get_logs():
+    """Return paginated log entries optionally filtered by search string."""
+
+    query = Log.query
+
+    search = request.args.get("search")
+    if search:
+        query = query.filter(Log.description.ilike(f"%{search}%"))
+
+    page = int(request.args.get("page", 1))
+    per_page = int(request.args.get("per_page", 10))
+
+    pagination = (
+        query.order_by(Log.timestamp.desc()).paginate(
+            page=page, per_page=per_page, error_out=False
+        )
+    )
+
+    return jsonify(
+        {
+            "total": pagination.total,
+            "page": pagination.page,
+            "per_page": pagination.per_page,
+            "logs": [log.to_dict() for log in pagination.items],
+        }
+    )
+

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -3,6 +3,7 @@ from .promo_code import PromoCode
 from .pending_plan import PendingPlan
 from .plan_history import PlanHistory
 from .price_history import PriceHistory
+from .log import Log
 
 __all__ = [
     "Plan",
@@ -10,4 +11,5 @@ __all__ = [
     "PendingPlan",
     "PlanHistory",
     "PriceHistory",
+    "Log",
 ]

--- a/backend/models/log.py
+++ b/backend/models/log.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from sqlalchemy import Column, String, DateTime
+
+from backend.db import db
+
+
+class Log(db.Model):
+    """Stores application log entries"""
+
+    __tablename__ = "logs"
+
+    id = Column(String, primary_key=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    user_id = Column(String)
+    username = Column(String)
+    ip_address = Column(String)
+    action = Column(String)
+    target = Column(String)
+    description = Column(String)
+    status = Column(String)
+    source = Column(String)
+    user_agent = Column(String)
+
+    def to_dict(self) -> dict:
+        """Serialize model to dictionary"""
+
+        return {
+            "id": self.id,
+            "timestamp": self.timestamp.isoformat(),
+            "user_id": self.user_id,
+            "username": self.username,
+            "ip_address": self.ip_address,
+            "action": self.action,
+            "target": self.target,
+            "description": self.description,
+            "status": self.status,
+            "source": self.source,
+            "user_agent": self.user_agent,
+        }
+

--- a/frontend/react/pages/AdminLogs.tsx
+++ b/frontend/react/pages/AdminLogs.tsx
@@ -1,9 +1,78 @@
 import React from 'react';
 
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
 const AdminLogs: React.FC = () => {
+  const [logs, setLogs] = useState<any[]>([]);
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const perPage = 10;
+
+  useEffect(() => {
+    axios
+      .get(`/api/admin/logs?search=${search}&page=${page}&per_page=${perPage}`)
+      .then((res) => {
+        setLogs(res.data.logs);
+        setTotal(res.data.total);
+      });
+  }, [search, page]);
+
   return (
     <div className="p-6">
-      <h1 className="text-xl font-semibold">Log Kayıtları</h1>
+      <h1 className="text-xl font-semibold mb-4">Log Kayıtları</h1>
+      <input
+        className="border p-2 mb-4 w-full"
+        type="text"
+        placeholder="Log ara..."
+        value={search}
+        onChange={(e) => {
+          setSearch(e.target.value);
+          setPage(1);
+        }}
+      />
+      <table className="min-w-full bg-white">
+        <thead>
+          <tr>
+            <th className="px-4 py-2">Zaman</th>
+            <th className="px-4 py-2">Kullanıcı</th>
+            <th className="px-4 py-2">Aksiyon</th>
+            <th className="px-4 py-2">Hedef</th>
+            <th className="px-4 py-2">Durum</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log, i) => (
+            <tr key={i} className="border-t">
+              <td className="px-4 py-2 text-sm">
+                {new Date(log.timestamp).toLocaleString()}
+              </td>
+              <td className="px-4 py-2 text-sm">{log.username}</td>
+              <td className="px-4 py-2 text-sm">{log.action}</td>
+              <td className="px-4 py-2 text-sm">{log.target}</td>
+              <td className="px-4 py-2 text-sm">{log.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex justify-between mt-4">
+        <button
+          disabled={page === 1}
+          onClick={() => setPage(page - 1)}
+          className="btn"
+        >
+          &larr; Geri
+        </button>
+        <span>Sayfa {page}</span>
+        <button
+          disabled={page * perPage >= total}
+          onClick={() => setPage(page + 1)}
+          className="btn"
+        >
+          İleri &rarr;
+        </button>
+      </div>
     </div>
   );
 };

--- a/migrations/versions/20251105_add_logs_table.py
+++ b/migrations/versions/20251105_add_logs_table.py
@@ -1,0 +1,32 @@
+"""Create logs table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20251105_01"
+down_revision = "20251010_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "logs",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("timestamp", sa.DateTime(), nullable=True),
+        sa.Column("user_id", sa.String(), nullable=True),
+        sa.Column("username", sa.String(), nullable=True),
+        sa.Column("ip_address", sa.String(), nullable=True),
+        sa.Column("action", sa.String(), nullable=True),
+        sa.Column("target", sa.String(), nullable=True),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), nullable=True),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column("user_agent", sa.String(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table("logs")
+


### PR DESCRIPTION
## Summary
- add `Log` model and expose via `__all__`
- implement `/api/admin/logs` endpoint and register the blueprint
- create migration to create `logs` table
- implement React admin page for logs

## Testing
- `pytest -q`
- `pytest backend/tests/test_decision.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf8be0f20832f81f52e46eeeb13ae