### PR TITLE
Implement database logging helper

### DIFF
--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+def create_log(
+    user_id: str,
+    username: str,
+    ip_address: str,
+    action: str,
+    target: str = "",
+    description: str = "",
+    status: str = "success",
+    source: str = "web",
+    user_agent: str = ""
+):
+    """Persist a simple application log entry."""
+    from backend import db
+    from backend.models.log import Log
+    from uuid import uuid4
+    import datetime
+
+    log = Log(
+        id=str(uuid4()),
+        timestamp=datetime.datetime.utcnow(),
+        user_id=user_id,
+        username=username,
+        ip_address=ip_address,
+        action=action,
+        target=target,
+        description=description,
+        status=status,
+        source=source,
+        user_agent=user_agent,
+    )
+    db.session.add(log)
+    db.session.commit()
+    return log

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,36 @@
+import pytest
+from backend import create_app, db
+from backend.models.log import Log
+from backend.utils.logger import create_log
+
+
+@pytest.fixture
+def test_app(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def test_create_log_inserts_entry(test_app):
+    with test_app.app_context():
+        create_log(
+            user_id="123",
+            username="tester",
+            ip_address="127.0.0.1",
+            action="login",
+            target="/login",
+            description="User login",
+        )
+        log = Log.query.filter_by(user_id="123", action="login").first()
+        assert log is not None
+        assert log.username == "tester"
+        assert log.ip_address == "127.0.0.1"
+        assert log.status == "success"
+        assert log.source == "web"
+


### PR DESCRIPTION
## Summary
- implement a new logger utility for creating log entries
- add unit test for logger

## Testing
- `pytest -q`
- `pytest tests/test_logger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688d3edc0ce8832fa5bf06813a2b97f2