### PR TITLE
Add admin log retrieval endpoint

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -247,6 +247,7 @@ def create_app():
     from backend.api.admin.system_events import events_bp
     from backend.api.admin.analytics import analytics_bp
     from backend.api.logs import logs_bp
+    from backend.api.admin.logs import admin_logs_bp
     from backend.limits.routes import limits_bp
     from backend.api.ta_routes import bp as ta_bp
     from backend.api.public.technical import technical_bp
@@ -277,6 +278,7 @@ def create_app():
     app.register_blueprint(events_bp)
     app.register_blueprint(analytics_bp)
     app.register_blueprint(logs_bp)
+    app.register_blueprint(admin_logs_bp, url_prefix='/api/admin')
     app.register_blueprint(ta_bp)
     app.register_blueprint(technical_bp)
     app.register_blueprint(decision_bp)

--- a/backend/api/admin/logs.py
+++ b/backend/api/admin/logs.py
@@ -1,0 +1,51 @@
+from flask import Blueprint, request, jsonify
+from backend.models.log import Log
+from datetime import datetime
+
+admin_logs_bp = Blueprint("admin_logs", __name__)
+
+@admin_logs_bp.route("/logs", methods=["GET"])
+def get_logs():
+    """Logları filtreleyip JSON döner."""
+    username = request.args.get("username")
+    action = request.args.get("action")
+    start = request.args.get("start_date")
+    end = request.args.get("end_date")
+    limit = int(request.args.get("limit", 50))
+    offset = int(request.args.get("offset", 0))
+
+    query = Log.query
+    if username:
+        query = query.filter(Log.username.ilike(f"%{username}%"))
+    if action:
+        query = query.filter(Log.action == action)
+    if start:
+        start_dt = datetime.fromisoformat(start)
+        query = query.filter(Log.timestamp >= start_dt)
+    if end:
+        end_dt = datetime.fromisoformat(end)
+        query = query.filter(Log.timestamp <= end_dt)
+
+    total = query.count()
+    logs = (
+        query.order_by(Log.timestamp.desc())
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+
+    results = [
+        {
+            "id": log.id,
+            "username": log.username,
+            "action": log.action,
+            "target": log.target,
+            "description": log.description,
+            "ip_address": log.ip_address,
+            "user_agent": log.user_agent,
+            "timestamp": log.timestamp.isoformat(),
+            "status": log.status,
+        }
+        for log in logs
+    ]
+    return jsonify({"total": total, "results": results})


### PR DESCRIPTION
## Summary
- add admin logs API for filtering and pagination
- wire admin logs blueprint into app factory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890fdf2e880832f956d8f4e45703b40