### PR TITLE
Add feature flag helper and tests for recommendation endpoint

### DIFF
--- a/backend/utils/feature_flags.py
+++ b/backend/utils/feature_flags.py
@@ -1,8 +1,28 @@
-from flask import current_app
+"""Geçici Feature Flag kontrol sistemi.
+
+İleride Redis veya DB destekli yapıya taşınabilir.
+"""
 
 
 def feature_flag_enabled(flag_name: str) -> bool:
-    """Return True if the given feature flag is enabled in app config."""
-    flags = current_app.config.get("FEATURE_FLAGS", {}) if current_app else {}
-    return bool(flags.get(flag_name, False))
+    """Return ``True`` if the feature flag is enabled.
+
+    Flags are currently stored in a static dictionary. This helper can be
+    replaced with a database- or Redis-backed implementation in the future.
+    """
+
+    enabled_flags = {
+        "recommendation_enabled": True,
+        # "advanced_forecast": False,
+        # "next_generation_model": False,
+    }
+    return enabled_flags.get(flag_name, False)
+
+
+def all_feature_flags() -> dict:
+    """Return a mapping of all feature flags and their states."""
+
+    return {
+        "recommendation_enabled": feature_flag_enabled("recommendation_enabled"),
+    }
 

--- a/tests/test_predict_routes.py
+++ b/tests/test_predict_routes.py
@@ -1,0 +1,38 @@
+"""Tests for prediction routes."""
+
+import pytest
+from flask import Flask
+
+from backend.routes.predict_routes import predict_bp
+
+
+@pytest.fixture
+def test_app():
+    """Create a Flask test client with the prediction blueprint."""
+
+    app = Flask(__name__)
+    app.register_blueprint(predict_bp, url_prefix="/api")
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_recommend_endpoint_enabled(test_app):
+    """``/api/recommend`` should respond with data or an error."""
+
+    response = test_app.post("/api/recommend")
+    assert response.status_code in [200, 403]
+    data = response.get_json()
+    if response.status_code == 200:
+        assert "recommendations" in data
+        assert isinstance(data["recommendations"], list)
+        assert len(data["recommendations"]) <= 5
+    else:
+        assert "error" in data
+
+
+def test_recommend_endpoint_method_not_allowed(test_app):
+    """Only POST method should be allowed on ``/api/recommend``."""
+
+    response = test_app.get("/api/recommend")
+    assert response.status_code == 405
+


### PR DESCRIPTION
## Summary
- implement temporary feature flag helper with static mapping and retrieval of all flags
- add tests for recommendation endpoint including method and response checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689101c98bcc832f84095570aa084dd0