### PR TITLE
Add admin log API tests and fix blueprint registration

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -246,7 +246,6 @@ def create_app():
     from backend.api.admin.backup import backup_bp
     from backend.api.admin.system_events import events_bp
     from backend.api.admin.analytics import analytics_bp
-    from backend.api.logs import logs_bp
     from backend.api.admin.logs import admin_logs_bp
     from backend.limits.routes import limits_bp
     from backend.api.ta_routes import bp as ta_bp
@@ -277,7 +276,6 @@ def create_app():
     app.register_blueprint(backup_bp)
     app.register_blueprint(events_bp)
     app.register_blueprint(analytics_bp)
-    app.register_blueprint(logs_bp)
     app.register_blueprint(admin_logs_bp, url_prefix='/api/admin')
     app.register_blueprint(ta_bp)
     app.register_blueprint(technical_bp)

--- a/tests/test_admin_logs_api.py
+++ b/tests/test_admin_logs_api.py
@@ -1,0 +1,84 @@
+import pytest
+from backend.models.log import Log
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+
+def create_log_entry(db, username="admin", action="login"):
+    log = Log(
+        id=str(uuid4()),
+        username=username,
+        action=action,
+        target="/api/auth/login",
+        description="Test login",
+        ip_address="127.0.0.1",
+        user_agent="pytest-agent",
+        status="success",
+        timestamp=datetime.utcnow() - timedelta(minutes=5),
+    )
+    db.session.add(log)
+    db.session.commit()
+    return log
+
+
+def test_get_logs(client, db):
+    create_log_entry(db)
+
+    response = client.get("/api/admin/logs")
+    assert response.status_code == 200
+
+    data = response.get_json()
+    assert "total" in data
+    assert "results" in data
+    assert data["total"] >= 1
+    assert any(entry["action"] == "login" for entry in data["results"])
+
+
+def test_logs_filter_by_username(client, db):
+    create_log_entry(db, username="admin")
+    create_log_entry(db, username="otheruser")
+
+    response = client.get("/api/admin/logs?username=admin")
+    assert response.status_code == 200
+
+    data = response.get_json()
+    for log in data["results"]:
+        assert "admin" in log["username"]
+
+
+def test_logs_filter_by_action(client, db):
+    create_log_entry(db, action="predict")
+    create_log_entry(db, action="llm_analyze")
+
+    response = client.get("/api/admin/logs?action=predict")
+    assert response.status_code == 200
+
+    data = response.get_json()
+    assert all(log["action"] == "predict" for log in data["results"])
+
+
+def test_logs_date_range(client, db):
+    log = create_log_entry(db)
+    start = (log.timestamp - timedelta(minutes=1)).isoformat()
+    end = (log.timestamp + timedelta(minutes=1)).isoformat()
+
+    response = client.get(f"/api/admin/logs?start_date={start}&end_date={end}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert any(entry["id"] for entry in data["results"])
+
+
+def test_logs_pagination(client, db):
+    for i in range(20):
+        create_log_entry(db, username=f"user{i}")
+
+    response = client.get("/api/admin/logs?limit=5&offset=0")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data["results"]) <= 5
+
+    response2 = client.get("/api/admin/logs?limit=5&offset=5")
+    assert response2.status_code == 200
+    data2 = response2.get_json()
+    assert len(data2["results"]) <= 5
+    assert data["results"] != data2["results"]


### PR DESCRIPTION
## Summary
- add test coverage for `/api/admin/logs` endpoint including username/action filtering, date range, and pagination
- register only `admin_logs_bp` to remove conflicting legacy logs route

## Testing
- `pytest tests/test_admin_logs_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689103744ff0832f80d60076ba00b34b