### PR TITLE
Expose feature flag states via admin endpoint

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -248,6 +248,7 @@ def create_app():
     from backend.api.admin.analytics import analytics_bp
     from backend.api.logs import logs_bp
     from backend.api.admin.logs import admin_logs_bp
+    from backend.api.admin.feature_flags import feature_flags_bp
     from backend.limits.routes import limits_bp
     from backend.api.ta_routes import bp as ta_bp
     from backend.api.public.technical import technical_bp
@@ -281,6 +282,7 @@ def create_app():
     app.register_blueprint(admin_logs_bp, url_prefix='/api/admin')
     app.register_blueprint(ta_bp)
     app.register_blueprint(technical_bp)
+    app.register_blueprint(feature_flags_bp, url_prefix="/api/admin")
     app.register_blueprint(decision_bp)
     app.register_blueprint(subscriptions_bp)
     app.register_blueprint(limits_bp)

--- a/backend/api/admin/feature_flags.py
+++ b/backend/api/admin/feature_flags.py
@@ -1,0 +1,14 @@
+from flask import Blueprint, jsonify
+
+from backend.utils.feature_flags import all_feature_flags
+
+
+feature_flags_bp = Blueprint("feature_flags", __name__)
+
+
+@feature_flags_bp.route("/feature-flags", methods=["GET"])
+def get_feature_flags():
+    """Return a mapping of feature flags and their states."""
+    flags = all_feature_flags()
+    return jsonify(flags)
+

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,0 +1,37 @@
+"""Tests for feature flag system."""
+
+import pytest
+from flask import Flask
+
+from backend.api.admin.feature_flags import feature_flags_bp
+from backend.utils.feature_flags import feature_flag_enabled, all_feature_flags
+
+
+def test_feature_flag_enabled_true():
+    assert feature_flag_enabled("recommendation_enabled") is True
+
+
+def test_feature_flag_enabled_false():
+    assert feature_flag_enabled("non_existent_feature") is False
+
+
+def test_all_feature_flags():
+    flags = all_feature_flags()
+    assert isinstance(flags, dict)
+    assert "recommendation_enabled" in flags
+
+
+@pytest.fixture
+def test_app():
+    app = Flask(__name__)
+    app.register_blueprint(feature_flags_bp, url_prefix="/api/admin")
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_get_feature_flags(test_app):
+    res = test_app.get("/api/admin/feature-flags")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert "recommendation_enabled" in data
+


### PR DESCRIPTION
## Summary
- add `/api/admin/feature-flags` endpoint to list feature flags
- register new blueprint
- test feature flag utilities and endpoint

## Testing
- `pytest tests/test_feature_flags.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68910746be88832fa7f0bca2fb03be03