### PR TITLE
Add configurable feature flags

### DIFF
--- a/backend/api/admin/feature_flags.py
+++ b/backend/api/admin/feature_flags.py
@@ -1,6 +1,6 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
-from backend.utils.feature_flags import all_feature_flags
+from backend.utils.feature_flags import all_feature_flags, set_feature_flag
 
 
 feature_flags_bp = Blueprint("feature_flags", __name__)
@@ -11,4 +11,23 @@ def get_feature_flags():
     """Return a mapping of feature flags and their states."""
     flags = all_feature_flags()
     return jsonify(flags)
+
+
+@feature_flags_bp.route("/feature-flags", methods=["PUT"])
+def update_feature_flags():
+    """Update one or more feature flags."""
+    updates = request.json
+    if not isinstance(updates, dict):
+        return jsonify({"error": "Invalid payload"}), 400
+
+    applied = {}
+    for flag, value in updates.items():
+        if isinstance(value, bool):
+            set_feature_flag(flag, value)
+            applied[flag] = value
+
+    return jsonify({
+        "updated": applied,
+        "all_flags": all_feature_flags()
+    })
 

--- a/backend/utils/feature_flags.py
+++ b/backend/utils/feature_flags.py
@@ -5,24 +5,27 @@
 
 
 def feature_flag_enabled(flag_name: str) -> bool:
-    """Return ``True`` if the feature flag is enabled.
+    """Return ``True`` if the feature flag is enabled."""
 
-    Flags are currently stored in a static dictionary. This helper can be
-    replaced with a database- or Redis-backed implementation in the future.
-    """
+    return _flags.get(flag_name, False)
 
-    enabled_flags = {
-        "recommendation_enabled": True,
-        # "advanced_forecast": False,
-        # "next_generation_model": False,
-    }
-    return enabled_flags.get(flag_name, False)
+
+def set_feature_flag(flag_name: str, value: bool) -> None:
+    """Update a specific feature flag."""
+    if flag_name in _flags:
+        _flags[flag_name] = value
+
+
+# Internal flag storage (can be replaced by Redis or DB in the future)
+_flags = {
+    "recommendation_enabled": True,
+    "next_generation_model": False,
+    "advanced_forecast": False,
+}
 
 
 def all_feature_flags() -> dict:
     """Return a mapping of all feature flags and their states."""
 
-    return {
-        "recommendation_enabled": feature_flag_enabled("recommendation_enabled"),
-    }
+    return {flag: feature_flag_enabled(flag) for flag in _flags}
 

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -35,3 +35,20 @@ def test_get_feature_flags(test_app):
     data = res.get_json()
     assert "recommendation_enabled" in data
 
+
+def test_update_feature_flag(test_app):
+    res = test_app.put("/api/admin/feature-flags", json={
+        "recommendation_enabled": False,
+        "next_generation_model": True
+    })
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["updated"]["recommendation_enabled"] is False
+    assert data["updated"]["next_generation_model"] is True
+
+
+def test_invalid_update_payload(test_app):
+    res = test_app.put("/api/admin/feature-flags", json=["not", "a", "dict"])
+    assert res.status_code == 400
+    assert "error" in res.get_json()
+


### PR DESCRIPTION
## Summary
- enable dynamic feature flag configuration via API
- extend admin API with a PUT endpoint for feature flags
- test feature flag updates and invalid payloads

## Testing
- `pytest tests/test_feature_flags.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68911983dcf4832f8969973374e811ef