### PR TITLE
feat: add redis-backed feature flag management

### DIFF
--- a/backend/utils/feature_flags.py
+++ b/backend/utils/feature_flags.py
@@ -3,29 +3,50 @@
 İleride Redis veya DB destekli yapıya taşınabilir.
 """
 
+from typing import Dict
+import os
+import redis
 
-def feature_flag_enabled(flag_name: str) -> bool:
-    """Return ``True`` if the feature flag is enabled."""
+USE_REDIS = os.getenv("USE_REDIS_FEATURE_FLAGS", "1") == "1"
 
-    return _flags.get(flag_name, False)
+try:
+    redis_client = redis.Redis.from_url(
+        os.getenv("REDIS_URL", "redis://localhost:6379"), decode_responses=True
+    )
+    redis_client.ping()
+except Exception:
+    redis_client = None
+    USE_REDIS = False
 
-
-def set_feature_flag(flag_name: str, value: bool) -> None:
-    """Update a specific feature flag."""
-    if flag_name in _flags:
-        _flags[flag_name] = value
-
-
-# Internal flag storage (can be replaced by Redis or DB in the future)
-_flags = {
+# Fallback in-memory store
+_default_flags = {
     "recommendation_enabled": True,
     "next_generation_model": False,
     "advanced_forecast": False,
 }
 
 
-def all_feature_flags() -> dict:
+def feature_flag_enabled(flag_name: str) -> bool:
+    """Return ``True`` if the feature flag is enabled."""
+    if USE_REDIS and redis_client:
+        value = redis_client.get(f"feature_flag:{flag_name}")
+        if value is None:
+            return False
+        return value == "true"
+    return _default_flags.get(flag_name, False)
+
+
+def set_feature_flag(flag_name: str, value: bool) -> None:
+    """Update a specific feature flag."""
+    if USE_REDIS and redis_client:
+        redis_client.set(f"feature_flag:{flag_name}", str(value).lower())
+    else:
+        if flag_name in _default_flags:
+            _default_flags[flag_name] = value
+
+
+def all_feature_flags() -> Dict[str, bool]:
     """Return a mapping of all feature flags and their states."""
-
-    return {flag: feature_flag_enabled(flag) for flag in _flags}
-
+    if USE_REDIS and redis_client:
+        return {flag: feature_flag_enabled(flag) for flag in _default_flags}
+    return {flag: _default_flags[flag] for flag in _default_flags}

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -4,7 +4,7 @@ import pytest
 from flask import Flask
 
 from backend.api.admin.feature_flags import feature_flags_bp
-from backend.utils.feature_flags import feature_flag_enabled, all_feature_flags
+from backend.utils.feature_flags import all_feature_flags, feature_flag_enabled
 
 
 def test_feature_flag_enabled_true():
@@ -37,18 +37,28 @@ def test_get_feature_flags(test_app):
 
 
 def test_update_feature_flag(test_app):
-    res = test_app.put("/api/admin/feature-flags", json={
-        "recommendation_enabled": False,
-        "next_generation_model": True
-    })
+    res = test_app.post(
+        "/api/admin/feature-flags/recommendation_enabled",
+        json={"enabled": False},
+    )
     assert res.status_code == 200
     data = res.get_json()
-    assert data["updated"]["recommendation_enabled"] is False
-    assert data["updated"]["next_generation_model"] is True
+    assert data["recommendation_enabled"] is False
+
+    # Restore to True for consistency
+    res = test_app.post(
+        "/api/admin/feature-flags/recommendation_enabled",
+        json={"enabled": True},
+    )
+    assert res.status_code == 200
+    assert res.get_json()["recommendation_enabled"] is True
 
 
-def test_invalid_update_payload(test_app):
-    res = test_app.put("/api/admin/feature-flags", json=["not", "a", "dict"])
+def test_invalid_update_request(test_app):
+    res = test_app.post(
+        "/api/admin/feature-flags/recommendation_enabled",
+        json={},
+    )
     assert res.status_code == 400
     assert "error" in res.get_json()
 


### PR DESCRIPTION
## Summary
- add Redis-based feature flag store with in-memory fallback
- expose admin API to toggle individual feature flags
- test feature flag updates and invalid requests

## Testing
- `pytest tests/test_feature_flags.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pycoingecko'; ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68924506404c832fb7be2366595411df