### PR TITLE
feat: add admin feature flag controls

### DIFF
--- a/frontend/react/AdminFeatureFlags.tsx
+++ b/frontend/react/AdminFeatureFlags.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { Switch } from './components/ui/switch';
+import { toast } from 'sonner';
+
+interface FeatureFlags {
+  [key: string]: boolean;
+}
+
+const AdminFeatureFlags: React.FC = () => {
+  const [flags, setFlags] = useState<FeatureFlags>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/admin/feature-flags')
+      .then((res) => res.json())
+      .then(setFlags)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const toggleFlag = (key: string, value: boolean) => {
+    fetch(`/api/admin/feature-flags/${key}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: value }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        setFlags((prev) => ({ ...prev, [key]: data[key] }));
+        toast.success(`${key} güncellendi: ${data[key] ? 'açık' : 'kapalı'}`);
+      })
+      .catch(() => {
+        toast.error('Güncelleme başarısız');
+      });
+  };
+
+  if (loading) return <p>Yükleniyor...</p>;
+
+  return (
+    <div className="p-6 max-w-2xl">
+      <h1 className="text-2xl font-bold mb-4">Feature Flag Yönetimi</h1>
+      <ul className="space-y-4">
+        {Object.entries(flags).map(([key, value]) => (
+          <li
+            key={key}
+            className="flex items-center justify-between bg-muted p-4 rounded-xl shadow-sm"
+          >
+            <span className="font-medium">{key}</span>
+            <Switch checked={value} onCheckedChange={(v) => toggleFlag(key, v)} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AdminFeatureFlags;

--- a/frontend/react/AdminRoutes.tsx
+++ b/frontend/react/AdminRoutes.tsx
@@ -9,6 +9,7 @@ import AdminLimits from './pages/AdminLimits';
 import AdminContent from './pages/AdminContent';
 import AdminMonitoring from './pages/AdminMonitoring';
 import AdminLogs from './pages/AdminLogs';
+import AdminFeatureFlags from './pages/AdminFeatureFlags';
 
 const AdminRoutes = () => {
   return (
@@ -21,6 +22,7 @@ const AdminRoutes = () => {
       <Route path="/admin/limits" element={<AdminLimits />} />
       <Route path="/admin/content" element={<AdminContent />} />
       <Route path="/admin/monitoring" element={<AdminMonitoring />} />
+      <Route path="/admin/feature-flags" element={<AdminFeatureFlags />} />
       <Route path="/admin/logs" element={<AdminLogs />} />
     </Routes>
   );

--- a/frontend/react/components/ui/switch.tsx
+++ b/frontend/react/components/ui/switch.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export interface SwitchProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  checked: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+export function Switch({ checked, onCheckedChange, className = '', ...props }: SwitchProps) {
+  return (
+    <label className={`relative inline-flex items-center cursor-pointer ${className}`}>
+      <input
+        type="checkbox"
+        className="sr-only peer"
+        checked={checked}
+        onChange={(e) => onCheckedChange?.(e.target.checked)}
+        {...props}
+      />
+      <div className="w-11 h-6 bg-gray-200 rounded-full peer peer-checked:bg-blue-600 peer-focus:ring-4 peer-focus:ring-blue-300 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:w-5 after:h-5 after:bg-white after:border after:rounded-full after:transition-all peer-checked:after:translate-x-full" />
+    </label>
+  );
+}
+
+export default Switch;

--- a/frontend/react/pages/AdminFeatureFlags.tsx
+++ b/frontend/react/pages/AdminFeatureFlags.tsx
@@ -1,0 +1,1 @@
+export { default } from '../AdminFeatureFlags';


### PR DESCRIPTION
## Summary
- add feature flag management route
- create feature flag page with toggle switch

## Testing
- `npm test --prefix frontend`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689247141e08832f8084b44e65313ad7