### PR TITLE
Add feature flag metadata and creation support

### DIFF
--- a/backend/api/admin/feature_flags.py
+++ b/backend/api/admin/feature_flags.py
@@ -4,6 +4,8 @@ from backend.utils.feature_flags import (
     all_feature_flags,
     feature_flag_enabled,
     set_feature_flag,
+    create_feature_flag,
+    get_feature_flag_metadata,
 )
 
 
@@ -14,7 +16,15 @@ feature_flags_bp = Blueprint("feature_flags", __name__)
 def get_feature_flags():
     """Return a mapping of feature flags and their states."""
     flags = all_feature_flags()
-    return jsonify(flags)
+    enriched = {}
+    for key, val in flags.items():
+        meta = get_feature_flag_metadata(key)
+        enriched[key] = {
+            "enabled": val,
+            "description": meta.get("description", ""),
+            "category": meta.get("category", "general"),
+        }
+    return jsonify(enriched)
 
 
 @feature_flags_bp.route("/feature-flags/<flag_name>", methods=["POST"])
@@ -29,3 +39,18 @@ def update_feature_flag(flag_name):
         return jsonify({flag_name: feature_flag_enabled(flag_name)})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+@feature_flags_bp.route("/feature-flags/create", methods=["POST"])
+def create_flag():
+    data = request.get_json()
+    required_fields = ["name", "enabled"]
+    if not all(field in data for field in required_fields):
+        return jsonify({"error": "Missing required fields"}), 400
+    create_feature_flag(
+        flag_name=data["name"],
+        enabled=bool(data["enabled"]),
+        description=data.get("description", ""),
+        category=data.get("category", "general"),
+    )
+    return jsonify({"status": "created", "flag": data["name"]})

--- a/frontend/react/AdminFeatureFlags.tsx
+++ b/frontend/react/AdminFeatureFlags.tsx
@@ -1,14 +1,27 @@
 import React, { useEffect, useState } from 'react';
 import { Switch } from './components/ui/switch';
 import { toast } from 'sonner';
+import { Button } from './components/ui/button';
+import { Input } from './components/ui/input';
 
 interface FeatureFlags {
-  [key: string]: boolean;
+  [key: string]: {
+    enabled: boolean;
+    description?: string;
+    category?: string;
+  };
 }
 
 const AdminFeatureFlags: React.FC = () => {
   const [flags, setFlags] = useState<FeatureFlags>({});
   const [loading, setLoading] = useState(true);
+
+  const [newFlag, setNewFlag] = useState({
+    name: '',
+    description: '',
+    category: '',
+    enabled: false,
+  });
 
   useEffect(() => {
     fetch('/api/admin/feature-flags')
@@ -25,7 +38,13 @@ const AdminFeatureFlags: React.FC = () => {
     })
       .then((res) => res.json())
       .then((data) => {
-        setFlags((prev) => ({ ...prev, [key]: data[key] }));
+        setFlags((prev) => ({
+          ...prev,
+          [key]: {
+            ...prev[key],
+            enabled: data[key],
+          },
+        }));
         toast.success(`${key} güncellendi: ${data[key] ? 'açık' : 'kapalı'}`);
       })
       .catch(() => {
@@ -36,19 +55,71 @@ const AdminFeatureFlags: React.FC = () => {
   if (loading) return <p>Yükleniyor...</p>;
 
   return (
-    <div className="p-6 max-w-2xl">
+    <div className="p-6 max-w-2xl space-y-8">
       <h1 className="text-2xl font-bold mb-4">Feature Flag Yönetimi</h1>
-      <ul className="space-y-4">
-        {Object.entries(flags).map(([key, value]) => (
-          <li
+      <div className="space-y-4">
+        {Object.entries(flags).map(([key, info]) => (
+          <div
             key={key}
-            className="flex items-center justify-between bg-muted p-4 rounded-xl shadow-sm"
+            className="flex flex-col bg-muted p-4 rounded-xl shadow-sm"
           >
-            <span className="font-medium">{key}</span>
-            <Switch checked={value} onCheckedChange={(v) => toggleFlag(key, v)} />
-          </li>
+            <div className="flex justify-between items-center">
+              <span className="font-medium">{key}</span>
+              <Switch checked={info.enabled} onCheckedChange={(v) => toggleFlag(key, v)} />
+            </div>
+            <p className="text-sm text-muted-foreground">{info.description}</p>
+            <span className="text-xs italic text-blue-600">{info.category}</span>
+          </div>
         ))}
-      </ul>
+      </div>
+
+      <div className="border-t pt-6 space-y-2">
+        <h2 className="text-lg font-semibold">Yeni Flag Ekle</h2>
+        <div className="flex flex-col space-y-2">
+          <Input
+            placeholder="Flag adı"
+            value={newFlag.name}
+            onChange={(e) => setNewFlag({ ...newFlag, name: e.target.value })}
+          />
+          <Input
+            placeholder="Açıklama"
+            value={newFlag.description}
+            onChange={(e) => setNewFlag({ ...newFlag, description: e.target.value })}
+          />
+          <Input
+            placeholder="Kategori"
+            value={newFlag.category}
+            onChange={(e) => setNewFlag({ ...newFlag, category: e.target.value })}
+          />
+          <div className="flex items-center space-x-2">
+            <Switch
+              checked={newFlag.enabled}
+              onCheckedChange={(v) => setNewFlag({ ...newFlag, enabled: v })}
+            />
+            <span>{newFlag.enabled ? 'Açık' : 'Kapalı'}</span>
+          </div>
+          <Button
+            onClick={() => {
+              fetch('/api/admin/feature-flags/create', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(newFlag),
+              })
+                .then((res) => res.json())
+                .then(() => {
+                  toast.success(`${newFlag.name} eklendi`);
+                  setNewFlag({ name: '', description: '', category: '', enabled: false });
+                  return fetch('/api/admin/feature-flags')
+                    .then((r) => r.json())
+                    .then(setFlags);
+                })
+                .catch(() => toast.error('Ekleme başarısız'));
+            }}
+          >
+            Ekle
+          </Button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -5,6 +5,7 @@ from flask import Flask
 
 from backend.api.admin.feature_flags import feature_flags_bp
 from backend.utils.feature_flags import all_feature_flags, feature_flag_enabled
+import backend.utils.feature_flags as feature_flags
 
 
 def test_feature_flag_enabled_true():
@@ -61,4 +62,75 @@ def test_invalid_update_request(test_app):
     )
     assert res.status_code == 400
     assert "error" in res.get_json()
+
+
+class DummyRedis:
+    def __init__(self):
+        self.store = {}
+        self.hstore = {}
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def hset(self, key, mapping):
+        self.hstore[key] = mapping
+
+    def hgetall(self, key):
+        return self.hstore.get(key, {})
+
+
+def test_create_flag_in_memory(test_app, monkeypatch):
+    monkeypatch.setattr(feature_flags, "USE_REDIS", False)
+    monkeypatch.setattr(feature_flags, "redis_client", None)
+    monkeypatch.setattr(
+        feature_flags, "_default_flags", dict(feature_flags._default_flags)
+    )
+    monkeypatch.setattr(feature_flags, "_default_flag_meta", {})
+
+    res = test_app.post(
+        "/api/admin/feature-flags/create",
+        json={
+            "name": "in_memory_flag",
+            "enabled": True,
+            "description": "In memory",
+            "category": "internal",
+        },
+    )
+    assert res.status_code == 200
+
+    res = test_app.get("/api/admin/feature-flags")
+    data = res.get_json()
+    assert data["in_memory_flag"]["enabled"] is True
+    assert data["in_memory_flag"]["description"] == "In memory"
+    assert data["in_memory_flag"]["category"] == "internal"
+
+
+def test_create_flag_redis(test_app, monkeypatch):
+    dummy = DummyRedis()
+    monkeypatch.setattr(feature_flags, "redis_client", dummy)
+    monkeypatch.setattr(feature_flags, "USE_REDIS", True)
+    monkeypatch.setattr(
+        feature_flags, "_default_flags", dict(feature_flags._default_flags)
+    )
+    monkeypatch.setattr(feature_flags, "_default_flag_meta", {})
+
+    res = test_app.post(
+        "/api/admin/feature-flags/create",
+        json={
+            "name": "redis_flag",
+            "enabled": False,
+            "description": "From redis",
+            "category": "beta",
+        },
+    )
+    assert res.status_code == 200
+
+    res = test_app.get("/api/admin/feature-flags")
+    data = res.get_json()
+    assert data["redis_flag"]["enabled"] is False
+    assert data["redis_flag"]["description"] == "From redis"
+    assert data["redis_flag"]["category"] == "beta"
 


### PR DESCRIPTION
## Summary
- Add helper functions to store feature flag metadata and create flags
- Expose metadata in admin API and add endpoint to create new flags
- Expand admin UI to display metadata and create feature flags
- Persist metadata in in-memory fallback and register new flags
- Add tests for flag creation endpoint across Redis and in-memory stores

## Testing
- `pytest tests/test_feature_flags.py::test_create_flag_in_memory tests/test_feature_flags.py::test_create_flag_redis -q`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892695acff8832f9179b3082d4ff034