### PR TITLE
feat: enhance feature flag system

### DIFF
--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -81,6 +81,12 @@ class DummyRedis:
     def hgetall(self, key):
         return self.hstore.get(key, {})
 
+    def sadd(self, key, value):
+        self.store.setdefault(key, set()).add(value)
+
+    def smembers(self, key):
+        return self.store.get(key, set())
+
 
 def test_create_flag_in_memory(test_app, monkeypatch):
     monkeypatch.setattr(feature_flags, "USE_REDIS", False)


### PR DESCRIPTION
## Summary
- track feature flag categories in Redis sets
- expose category-based flag lookup, and JSON export/import helpers
- extend tests' DummyRedis to handle set ops for new API

## Testing
- `pip install -r requirements-dev.txt`
- `pip install pandas pycoingecko`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892784e7278832f9337f354e65dbff9