### PR TITLE
Add feature flag export/import with category filter

### DIFF
--- a/backend/api/admin/feature_flags.py
+++ b/backend/api/admin/feature_flags.py
@@ -1,4 +1,8 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, g
+import json
+
+from backend.auth.jwt_utils import jwt_required_if_not_testing
+from backend.utils.logger import create_log
 
 from backend.utils.feature_flags import (
     all_feature_flags,
@@ -12,9 +16,30 @@ from backend.utils.feature_flags import (
 feature_flags_bp = Blueprint("feature_flags", __name__)
 
 
+def _log_flag_action(action: str, description: str = "") -> None:
+    """Flag işlemlerini logla."""
+    user = g.get("user")
+    if not user:
+        return
+    try:
+        create_log(
+            user_id=str(user.id),
+            username=user.username,
+            ip_address=request.remote_addr or "unknown",
+            action=action,
+            target=request.path,
+            description=description,
+            status="success",
+            user_agent=request.headers.get("User-Agent", ""),
+        )
+    except Exception:
+        pass
+
+
 @feature_flags_bp.route("/feature-flags", methods=["GET"])
+@jwt_required_if_not_testing()
 def get_feature_flags():
-    """Return a mapping of feature flags and their states."""
+    """Tüm feature flag'leri ve durumlarını döndür."""
     flags = all_feature_flags()
     enriched = {}
     for key, val in flags.items():
@@ -28,8 +53,9 @@ def get_feature_flags():
 
 
 @feature_flags_bp.route("/feature-flags/<flag_name>", methods=["POST"])
+@jwt_required_if_not_testing()
 def update_feature_flag(flag_name):
-    """Enable or disable a feature flag."""
+    """Bir feature flag'i aç veya kapat."""
     data = request.get_json()
     if not data or "enabled" not in data:
         return jsonify({"error": "Missing 'enabled' field"}), 400
@@ -42,6 +68,7 @@ def update_feature_flag(flag_name):
 
 
 @feature_flags_bp.route("/feature-flags/create", methods=["POST"])
+@jwt_required_if_not_testing()
 def create_flag():
     data = request.get_json()
     required_fields = ["name", "enabled"]
@@ -53,4 +80,54 @@ def create_flag():
         description=data.get("description", ""),
         category=data.get("category", "general"),
     )
+    _log_flag_action("feature_flag_create", f"Yeni flag: {data['name']}")
     return jsonify({"status": "created", "flag": data["name"]})
+
+
+@feature_flags_bp.route("/feature-flags/export", methods=["GET"])
+@jwt_required_if_not_testing()
+def export_flags():
+    """Tüm flag'leri JSON olarak dışa aktar."""
+    from backend.utils.feature_flags import export_all_flags
+
+    try:
+        data = json.loads(export_all_flags())
+        _log_flag_action("feature_flags_export", "Flagler dışa aktarıldı")
+        return jsonify(data)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@feature_flags_bp.route("/feature-flags/import", methods=["POST"])
+@jwt_required_if_not_testing()
+def import_flags():
+    """JSON verisinden flag'leri içe aktar."""
+    from backend.utils.feature_flags import import_flags_from_json
+
+    data = request.get_json()
+    try:
+        import_flags_from_json(json.dumps(data))
+        _log_flag_action("feature_flags_import", "Flagler içe aktarıldı")
+        return jsonify({"status": "imported"})
+    except Exception as e:
+        _log_flag_action("feature_flags_import_error", str(e))
+        return jsonify({"error": str(e)}), 400
+
+
+@feature_flags_bp.route("/feature-flags/category/<category>", methods=["GET"])
+@jwt_required_if_not_testing()
+def get_flags_by_category(category):
+    """Belirli kategoriye ait flag'leri döndür."""
+    from backend.utils.feature_flags import get_flags_by_category, get_feature_flag_metadata
+
+    flags = get_flags_by_category(category)
+    enriched = {}
+    for key, val in flags.items():
+        meta = get_feature_flag_metadata(key)
+        enriched[key] = {
+            "enabled": val,
+            "description": meta.get("description", ""),
+            "category": meta.get("category", "general"),
+        }
+    _log_flag_action("feature_flags_list_category", f"Kategori: {category}")
+    return jsonify(enriched)

--- a/frontend/react/AdminFeatureFlags.tsx
+++ b/frontend/react/AdminFeatureFlags.tsx
@@ -15,6 +15,7 @@ interface FeatureFlags {
 const AdminFeatureFlags: React.FC = () => {
   const [flags, setFlags] = useState<FeatureFlags>({});
   const [loading, setLoading] = useState(true);
+  const [categoryFilter, setCategoryFilter] = useState<string>('');
 
   const [newFlag, setNewFlag] = useState({
     name: '',
@@ -24,11 +25,14 @@ const AdminFeatureFlags: React.FC = () => {
   });
 
   useEffect(() => {
-    fetch('/api/admin/feature-flags')
+    const endpoint = categoryFilter
+      ? `/api/admin/feature-flags/category/${categoryFilter}`
+      : '/api/admin/feature-flags';
+    fetch(endpoint)
       .then((res) => res.json())
       .then(setFlags)
       .finally(() => setLoading(false));
-  }, []);
+  }, [categoryFilter]);
 
   const toggleFlag = (key: string, value: boolean) => {
     fetch(`/api/admin/feature-flags/${key}`, {
@@ -55,8 +59,16 @@ const AdminFeatureFlags: React.FC = () => {
   if (loading) return <p>Yükleniyor...</p>;
 
   return (
-    <div className="p-6 max-w-2xl space-y-8">
+    <div className="p-6 max-w-3xl space-y-8">
       <h1 className="text-2xl font-bold mb-4">Feature Flag Yönetimi</h1>
+      <div className="flex items-center space-x-2">
+        <Input
+          placeholder="Kategoriye göre filtrele"
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+        />
+        <Button onClick={() => setCategoryFilter('')}>Temizle</Button>
+      </div>
       <div className="space-y-4">
         {Object.entries(flags).map(([key, info]) => (
           <div
@@ -118,6 +130,50 @@ const AdminFeatureFlags: React.FC = () => {
           >
             Ekle
           </Button>
+        </div>
+      </div>
+
+      <div className="border-t pt-6 space-y-2">
+        <h2 className="text-lg font-semibold">Export / Import</h2>
+        <div className="flex flex-col space-y-2">
+          <Button
+            variant="outline"
+            onClick={() => {
+              fetch('/api/admin/feature-flags/export')
+                .then((res) => res.json())
+                .then((data) => {
+                  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+                  const url = URL.createObjectURL(blob);
+                  const a = document.createElement('a');
+                  a.href = url;
+                  a.download = 'feature-flags.json';
+                  a.click();
+                });
+            }}
+          >
+            Export JSON
+          </Button>
+          <textarea
+            className="border p-2 rounded-md text-sm"
+            placeholder="JSON yapıştırın..."
+            rows={6}
+            onBlur={(e) => {
+              const parsed = JSON.parse(e.target.value);
+              fetch('/api/admin/feature-flags/import', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(parsed),
+              })
+                .then((res) => res.json())
+                .then(() => {
+                  toast.success('Import başarılı');
+                  return fetch('/api/admin/feature-flags')
+                    .then((r) => r.json())
+                    .then(setFlags);
+                })
+                .catch(() => toast.error('Import başarısız'));
+            }}
+          />
         </div>
       </div>
     </div>

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,5 +1,7 @@
 """Tests for feature flag system."""
 
+import os
+os.environ["FLASK_ENV"] = "testing"
 import pytest
 from flask import Flask
 
@@ -24,6 +26,7 @@ def test_all_feature_flags():
 
 @pytest.fixture
 def test_app():
+    os.environ["FLASK_ENV"] = "testing"
     app = Flask(__name__)
     app.register_blueprint(feature_flags_bp, url_prefix="/api/admin")
     app.config["TESTING"] = True
@@ -86,6 +89,67 @@ class DummyRedis:
 
     def smembers(self, key):
         return self.store.get(key, set())
+
+
+def test_export_feature_flags(test_app):
+    res = test_app.get("/api/admin/feature-flags/export")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert "flags" in data and "meta" in data
+
+
+def test_export_feature_flags_error(test_app, monkeypatch):
+    def _raise():
+        raise ValueError("boom")
+
+    monkeypatch.setattr(feature_flags, "export_all_flags", _raise)
+    res = test_app.get("/api/admin/feature-flags/export")
+    assert res.status_code == 500
+    assert "error" in res.get_json()
+
+
+def test_import_feature_flags(test_app, monkeypatch):
+    monkeypatch.setattr(feature_flags, "_default_flags", {})
+    monkeypatch.setattr(feature_flags, "_default_flag_meta", {})
+    payload = {
+        "flags": {"new_flag": True},
+        "meta": {"new_flag": {"description": "desc", "category": "cat"}},
+    }
+    res = test_app.post("/api/admin/feature-flags/import", json=payload)
+    assert res.status_code == 200
+    res = test_app.get("/api/admin/feature-flags")
+    data = res.get_json()
+    assert data["new_flag"]["enabled"] is True
+    assert data["new_flag"]["category"] == "cat"
+
+
+def test_import_feature_flags_invalid_payload(test_app):
+    res = test_app.post("/api/admin/feature-flags/import", json="invalid")
+    assert res.status_code == 400
+    assert "error" in res.get_json()
+
+
+def test_get_flags_by_category(test_app, monkeypatch):
+    monkeypatch.setattr(feature_flags, "_default_flags", {})
+    monkeypatch.setattr(feature_flags, "_default_flag_meta", {})
+    payload = {
+        "flags": {"a": True, "b": False},
+        "meta": {
+            "a": {"description": "", "category": "cat1"},
+            "b": {"description": "", "category": "cat2"},
+        },
+    }
+    test_app.post("/api/admin/feature-flags/import", json=payload)
+    res = test_app.get("/api/admin/feature-flags/category/cat1")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert list(data.keys()) == ["a"]
+
+
+def test_get_flags_by_category_unknown(test_app):
+    res = test_app.get("/api/admin/feature-flags/category/unknown")
+    assert res.status_code == 200
+    assert res.get_json() == {}
 
 
 def test_create_flag_in_memory(test_app, monkeypatch):


### PR DESCRIPTION
## Summary
- add JWT-protected feature flag export, import and category endpoints with logging
- enhance admin feature flag UI with category filter and JSON export/import tools
- add tests covering export/import/category endpoints including invalid payload handling

## Testing
- `pytest tests/test_feature_flags.py`


------
https://chatgpt.com/codex/tasks/task_e_689287d3258c832fa9139e2b9e9889db