### PR TITLE
feat(frontend): add variant-based button component

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
       "name": "ytd-frontend",
       "dependencies": {
         "axios": "^1.11.0",
+        "class-variance-authority": "^0.7.0",
         "lucide-react": "^0.525.0",
         "react-router-dom": "^6.23.0",
         "reactstrap": "^9.2.3",
@@ -2280,6 +2281,18 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -2297,6 +2310,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -8871,6 +8893,14 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true
     },
+    "class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "requires": {
+        "clsx": "^2.1.1"
+      }
+    },
     "classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -8886,6 +8916,11 @@
         "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
     },
     "co": {
       "version": "4.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
+    "class-variance-authority": "^0.7.0",
     "lucide-react": "^0.525.0",
     "react-router-dom": "^6.23.0",
     "reactstrap": "^9.2.3",

--- a/frontend/react/components/ui/button.tsx
+++ b/frontend/react/components/ui/button.tsx
@@ -1,12 +1,60 @@
-import React from 'react';
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "../../lib/utils"
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+// Buton varyantları ve boyutları için stil tanımları
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        // Varsayılan buton stili
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        // Yıkıcı eylemler için buton stili
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        // Sınır çizgili buton stili
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        // İkincil buton stili
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        // Gölgeli buton stili
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        // Link gibi görünen buton stili
+        link: "underline-offset-4 hover:underline text-primary",
+      },
+      size: {
+        // Varsayılan boyut
+        default: "h-10 px-4 py-2",
+        // Küçük boyut
+        sm: "h-9 px-3 rounded-md",
+        // Büyük boyut
+        lg: "h-11 px-8 rounded-md",
+        // İkon buton boyutu
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
 
-export function Button({ className = '', ...props }: ButtonProps) {
-  return (
-    <button
-      className={`px-3 py-1 bg-blue-600 text-white rounded disabled:opacity-50 ${className}`}
-      {...props}
-    />
-  );
-}
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+// Tek sorumluluğu buton render etmek olan temel bileşen
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/frontend/react/lib/utils.ts
+++ b/frontend/react/lib/utils.ts
@@ -1,0 +1,6 @@
+import classNames from "classnames"
+
+// Tailwind sınıflarını güvenli şekilde birleştiren yardımcı fonksiyon
+export function cn(...inputs: classNames.ArgumentArray) {
+  return classNames(...inputs)
+}


### PR DESCRIPTION
## Summary
- enhance button component with variant and size options
- add class merging utility and dependency

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892927ba458832f81393a103b357e91