### PR TITLE
feat(frontend): add icon button and dark variant

### DIFF
--- a/frontend/react/components/ui/__tests__/button.test.tsx
+++ b/frontend/react/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { Button } from "../button"
+
+// Button bileşeni için temel testler
+describe("Button", () => {
+  it("renders default variant", () => {
+    render(<Button>Click me</Button>)
+    expect(screen.getByRole("button", { name: /click me/i })).toBeInTheDocument()
+  })
+
+  it("applies variant and size", () => {
+    render(
+      <Button variant="secondary" size="lg">
+        Large
+      </Button>
+    )
+    const btn = screen.getByRole("button")
+    expect(btn).toHaveClass("bg-secondary")
+    expect(btn).toHaveClass("h-11")
+  })
+
+  it("renders disabled state", () => {
+    render(<Button disabled>Disabled</Button>)
+    expect(screen.getByRole("button")).toBeDisabled()
+  })
+})

--- a/frontend/react/components/ui/button.tsx
+++ b/frontend/react/components/ui/button.tsx
@@ -8,6 +8,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
+        // Karanlık tema uyumlu buton stili
+        dark: "dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700",
         // Varsayılan buton stili
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         // Yıkıcı eylemler için buton stili
@@ -56,5 +58,22 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   }
 )
 Button.displayName = "Button"
+
+// Storybook ve test senaryolarında kullanılacak ikon destekli buton
+export interface ButtonIconProps extends ButtonProps {
+  iconLeft?: React.ReactNode
+  iconRight?: React.ReactNode
+}
+
+export const IconButton = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
+  ({ iconLeft, iconRight, children, className, ...props }, ref) => (
+    <Button ref={ref} className={cn("gap-2", className)} {...props}>
+      {iconLeft}
+      {children}
+      {iconRight}
+    </Button>
+  )
+)
+IconButton.displayName = "IconButton"
 
 export { Button, buttonVariants }

--- a/frontend/react/lib/utils.ts
+++ b/frontend/react/lib/utils.ts
@@ -4,3 +4,15 @@ import classNames from "classnames"
 export function cn(...inputs: classNames.ArgumentArray) {
   return classNames(...inputs)
 }
+
+// Tailwind safelist'e eklenmesi gereken varyant sınıfları
+export const safelistVariants = [
+  "bg-primary",
+  "bg-secondary",
+  "bg-destructive",
+  "hover:bg-accent",
+  "text-primary",
+  "text-secondary",
+  "text-destructive",
+  "text-white",
+]


### PR DESCRIPTION
## Summary
- extend button component with dark variant and icon support
- expose Tailwind safelist variants
- add unit tests for Button component

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ba65207c832f9f41106008a259a2