### PR TITLE
feat: allow optional auth on health endpoints

### DIFF
--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,13 +1,18 @@
 import os
 import json
+import importlib
+import sys
+from flask import Flask
+from flask_jwt_extended import JWTManager
 
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 os.environ["FLASK_ENV"] = "testing"
 
-from backend.app import create_app
+import backend.app as app_module
 
 
 def test_health_ok():
-    app = create_app()
+    app = app_module.create_app()
     client = app.test_client()
     rv = client.get("/health")
     assert rv.status_code == 200
@@ -16,9 +21,28 @@ def test_health_ok():
 
 
 def test_ready_ok():
-    app = create_app()
+    app = app_module.create_app()
     client = app.test_client()
     rv = client.get("/ready")
     assert rv.status_code == 200
     data = json.loads(rv.data)
     assert data.get("status") == "ready"
+
+
+def test_health_requires_auth_when_enabled(monkeypatch):
+    """Auth zorunlu olduğunda yetkisiz erişim reddedilmeli."""
+    monkeypatch.setenv("REQUIRE_AUTH_FOR_HEALTH", "true")
+    monkeypatch.setenv("FLASK_ENV", "development")
+    import backend.app.health as health_mod
+    importlib.reload(health_mod)
+    app = Flask(__name__)
+    app.config["JWT_SECRET_KEY"] = "test"
+    JWTManager(app)
+    app.register_blueprint(health_mod.bp)
+    client = app.test_client()
+    rv = client.get("/health")
+    assert rv.status_code == 401
+    # Ortamı ve modülleri eski haline getir
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.delenv("REQUIRE_AUTH_FOR_HEALTH", raising=False)
+    importlib.reload(health_mod)


### PR DESCRIPTION
## Summary
- make `/health` and `/ready` auth optional via `REQUIRE_AUTH_FOR_HEALTH`
- add tests for health endpoints with optional auth

## Testing
- `pytest backend/tests/test_health.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68988ea151d8832f9fc3c325c3b510e8