### PR TITLE
Add auth enforcement test for ready endpoint

### DIFF
--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -46,3 +46,22 @@ def test_health_requires_auth_when_enabled(monkeypatch):
     monkeypatch.setenv("FLASK_ENV", "testing")
     monkeypatch.delenv("REQUIRE_AUTH_FOR_HEALTH", raising=False)
     importlib.reload(health_mod)
+
+
+def test_ready_requires_auth_when_enabled(monkeypatch):
+    """Auth zorunlu olduğunda /ready yetkisiz erişimi reddetmeli."""
+    monkeypatch.setenv("REQUIRE_AUTH_FOR_HEALTH", "true")
+    monkeypatch.setenv("FLASK_ENV", "development")
+    import backend.app.health as health_mod
+    importlib.reload(health_mod)
+    app = Flask(__name__)
+    app.config["JWT_SECRET_KEY"] = "test"
+    JWTManager(app)
+    app.register_blueprint(health_mod.bp)
+    client = app.test_client()
+    rv = client.get("/ready")
+    assert rv.status_code == 401
+    # ortamı geri al
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.delenv("REQUIRE_AUTH_FOR_HEALTH", raising=False)
+    importlib.reload(health_mod)


### PR DESCRIPTION
## Summary
- add regression test to ensure /ready endpoint enforces auth when required

## Testing
- `pytest backend/tests/test_health.py -q --override-ini addopts="" -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_6898964abed8832f893feb821a7d6f10