### PR TITLE
ci: set port env for health check container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           docker run -d -p 5000:5000 --name ytd-ci \
             -e FF_HEALTH_CHECK=true \
             -e REQUIRE_AUTH_FOR_HEALTH=false \
+            -e PORT=5000 \
             ytd-kopya:ci
           for i in {1..20}; do
             sleep 2


### PR DESCRIPTION
## Summary
- add PORT env variable when starting CI health-check container

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch==2.1.0)*
- `pytest backend/tests/test_health.py`

------
https://chatgpt.com/codex/tasks/task_e_68989f9c9c5c832fa1cf16f9603a9a51