### PR TITLE
chore: skip heavy imports in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           docker run -d -p 5000:5000 --name ytd-ci \
             -e FF_HEALTH_CHECK=true \
             -e REQUIRE_AUTH_FOR_HEALTH=false \
+            -e SKIP_HEAVY_IMPORTS=true \
             -e PORT=5000 \
             ytd-kopya:ci
           for i in {1..20}; do

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -220,6 +220,7 @@ def create_app() -> Flask:
     from backend.auth.routes import auth_bp
     from backend.api.routes import api_bp
     from backend.admin_panel.routes import admin_bp
+    # plan_bp importunu proxy üzerinden yap (backend/api/plan.py)
     from backend.api.plan import plan_bp
     from backend.api.admin.plans import plan_admin_bp
     from backend.api.plan_admin_limits import plan_admin_limits_bp
@@ -241,16 +242,16 @@ def create_app() -> Flask:
     from backend.api.public.subscriptions import subscriptions_bp
     from backend.api.decision import decision_bp
 
-    # predict_routes ağır bağımlılıklara (pandas/numpy/pandas_ta/…)
-    # dayanıyorsa CI/Smoke’ta import etmeyelim:
+    # Ağır bağımlılıkları gerektiren blueprint'i CI/Smoke ortamında yükleme
     def _maybe_import_predict_bp():
-        if _is_skip_heavy():
-            logger.info("SKIP_HEAVY_IMPORTS aktif; predict_routes yüklenmiyor.")
+        val = os.getenv("SKIP_HEAVY_IMPORTS", "false").strip().lower()
+        if val in {"1", "true", "yes", "on"}:
+            logger.info("SKIP_HEAVY_IMPORTS aktif, predict_routes yüklenmiyor.")
             return None
         try:
-            from backend.routes.predict_routes import predict_bp  # pandas vb. gerektirebilir
+            from backend.routes.predict_routes import predict_bp
             return predict_bp
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover
             logger.warning(f"predict_routes yüklenemedi: {exc}")
             return None
 

--- a/backend/api/plan.py
+++ b/backend/api/plan.py
@@ -1,14 +1,12 @@
-*** Yeni dosya: backend/api/plan.py ***
-+"""
-+Plan API blueprint proxy dosyası.
-+Eski import yollarının bozulmaması için bu dosya eklenmiştir.
-+"""
-+
-+try:
-+    # Eğer plan bir klasör ve routes.py içinde tanımlıysa
-+    from backend.api.plan.routes import plan_bp
-+except ModuleNotFoundError:
-+    # Eğer plan doğrudan __init__.py içinde tanımlıysa
-+    from backend.api.plan import plan_bp
-+
-+__all__ = ["plan_bp"]
+"""Plan API blueprint proxy.
+
+Eski import yolu `from backend.api.plan import plan_bp` olan yerler için
+gerçek blueprint'i `plan_routes` modülünden dışa aktarır.
+"""
+
+# Projedeki gerçek blueprint `backend/api/plan_routes.py` içinde tanımlı.
+# Konum değişikliğinde tek noktadan yönlendirme yapabilmek için proxy kullanılır.
+from backend.api.plan_routes import plan_bp  # noqa: F401
+
+__all__ = ["plan_bp"]
+


### PR DESCRIPTION
## Summary
- add blueprint proxy for plan routes
- conditionally load prediction routes to skip heavy imports
- skip heavy imports in CI smoke tests

## Testing
- `SKIP_HEAVY_IMPORTS=true pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898ec912648832f8b3274aedf4b9654