### PR TITLE
Expose service port and extend CI health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,12 @@ jobs:
             -e FF_HEALTH_CHECK=true \
             -e REQUIRE_AUTH_FOR_HEALTH=false \
             -e SKIP_HEAVY_IMPORTS=true \
-            -e PORT=5000 \
             -e HOST=0.0.0.0 \
+            -e FLASK_RUN_HOST=0.0.0.0 \
+            -e PORT=5000 \
             ytd-kopya:ci
-          for i in {1..20}; do
+          # Servisin ayağa kalkması için biraz bekle ve denemeleri artır
+          for i in {1..30}; do
             sleep 2
             curl -fsS http://127.0.0.1:5000/health && exit 0 || true
           done

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,4 +12,11 @@ COPY backend ./backend
 COPY frontend ./frontend
 COPY wsgi.py ./wsgi.py
 
+# Varsayılan servis portu
+EXPOSE 5000
+# Konteyner içinden dışarıya dinleme adresi/portu
+ENV HOST=0.0.0.0
+ENV PORT=5000
+
+# Giriş noktası: wsgi.py (socketio.run host/port'u env'den okur)
 CMD ["python", "wsgi.py"]


### PR DESCRIPTION
## Summary
- expose default backend port and set host/port env vars in Dockerfile
- wait longer for health check and set host in CI workflow

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68990ec708ec832fbc652f9d5ae37a67