### PR TITLE
Add staging deployment workflow and Docker setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,39 +1,52 @@
-# Genel
+# ---------- GENERAL ----------
 FLASK_ENV=development
-SECRET_KEY=
+SECRET_KEY=change-me
 
-# Database
+# ---------- DATABASE ----------
 DATABASE_URL=postgresql://user:password@localhost:5432/ytdcrypto
 
-# Redis
+# ---------- REDIS ----------
 REDIS_URL=redis://localhost:6379/0
 
-# Celery
+# ---------- CELERY ----------
 CELERY_BROKER_URL=${REDIS_URL}
 CELERY_RESULT_BACKEND=${REDIS_URL}
 
-# Iyzico (ödeme sağlayıcı)
+# ---------- PAYMENT (IYZICO) ----------
 IYZICO_API_KEY=
 IYZICO_SECRET=
 IYZICO_BASE_URL=https://api.iyzipay.com
 
-# JWT
-JWT_SECRET_KEY=
-JWT_ACCESS_TOKEN_EXPIRES=3600    # saniye
-JWT_REFRESH_TOKEN_EXPIRES=86400  # saniye
+# ---------- JWT ----------
+JWT_SECRET_KEY=change-me-too
+JWT_ACCESS_TOKEN_EXPIRES=3600    # seconds
+JWT_REFRESH_TOKEN_EXPIRES=86400  # seconds
 
-# Mail (opsiyonel, şifre sıfırlama için)
+# ---------- MAIL (OPTIONAL) ----------
 MAIL_SERVER=
 MAIL_PORT=587
 MAIL_USE_TLS=true
 MAIL_USERNAME=
 MAIL_PASSWORD=
 
-# Diğer ayarlar
+# ---------- PLAN PRICING ----------
 BACKEND_PLAN_PRICES_BASIC=9.99
 BACKEND_PLAN_PRICES_ADVANCED=24.99
 BACKEND_PLAN_PRICES_PREMIUM=49.99
 
-# Otomatik Uyarılar için
+# ---------- ALERTING ----------
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
-ADMIN_ALERT_EMAIL=senin@email.com
+ADMIN_ALERT_EMAIL=admin@example.com
+
+# ---------- STAGING / INFRA ----------
+# Hostname for staging Caddy reverse proxy
+STAGING_FQDN=staging.example.com
+
+# Backend app import paths (comma separated)
+APP_IMPORT_CANDIDATES=backend.app:create_app,backend.app:app,app:create_app,app:app
+
+# Optional Gunicorn tuning for backend containers
+GUNICORN_WORKERS=4
+GUNICORN_THREADS=4
+
+# Create a .env.staging on the server and override secrets (real DB creds, API keys, etc.)

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,141 @@
+name: Staging CI/CD
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "docker-compose.staging.yml"
+      - "infra/**"
+      - ".github/workflows/staging.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BACKEND: ghcr.io/${{ github.repository }}-backend
+  IMAGE_FRONTEND: ghcr.io/${{ github.repository }}-frontend
+
+jobs:
+  test-backend:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+        ports: [ "5432:5432" ]
+        options: >-
+          --health-cmd="pg_isready -U postgres -d test_db"
+          --health-interval=10s --health-timeout=5s --health-retries=5
+      redis:
+        image: redis:7-alpine
+        ports: [ "6379:6379" ]
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s --health-timeout=5s --health-retries=5
+    env:
+      DATABASE_URL: postgresql+psycopg2://postgres:postgres@localhost:5432/test_db
+      REDIS_URL: redis://localhost:6379/0
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          # Kök + backend + dev requirements (varsa)
+          if [ -f ../requirements.txt ]; then pip install -r ../requirements.txt; fi
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f ../requirements-dev.txt ]; then pip install -r ../requirements-dev.txt; fi
+          # pytest yoksa yedek kurulum
+          python - <<'PY'
+          import importlib, sys, subprocess
+          try:
+              importlib.import_module("pytest")
+          except ImportError:
+              sys.exit(subprocess.call([sys.executable, "-m", "pip", "install", "pytest"]))
+          PY
+      - name: Run tests
+        run: |
+          if [ -d tests ]; then pytest -q || pytest -q -x; else echo "No tests"; fi
+
+  build-backend:
+    needs: test-backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build & push backend
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_BACKEND }}:sha-${{ github.sha }}
+            ${{ env.IMAGE_BACKEND }}:staging
+          cache-from: type=registry,ref=${{ env.IMAGE_BACKEND }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_BACKEND }}:buildcache,mode=max
+
+  build-frontend:
+    # frontend yoksa job tamamen atlanır (skip == success sayılır)
+    if: ${{ hashFiles('frontend/package.json') != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build & push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_FRONTEND }}:sha-${{ github.sha }}
+            ${{ env.IMAGE_FRONTEND }}:staging
+          cache-from: type=registry,ref=${{ env.IMAGE_FRONTEND }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_FRONTEND }}:buildcache,mode=max
+
+  deploy-staging:
+    needs: [ build-backend, build-frontend ]
+    runs-on: ubuntu-latest
+    concurrency:
+      group: staging-deploy
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.STAGING_SSH_HOST }}
+          username: ${{ secrets.STAGING_SSH_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          script_stop: true
+          script: |
+            cd ${{ secrets.STAGING_PROJECT_DIR }}
+            export GITHUB_SHA=${{ github.sha }}
+            docker login ${{ env.REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+            docker compose -f docker-compose.staging.yml pull
+            docker compose -f docker-compose.staging.yml up -d --remove-orphans
+            docker image prune -f

--- a/README_STAGING.md
+++ b/README_STAGING.md
@@ -1,0 +1,28 @@
+# Staging CI/CD Kılavuzu (Kısa)
+
+## 1) Sunucu Hazırlığı
+```bash
+sudo apt-get update && sudo apt-get install -y docker.io docker-compose-plugin
+sudo usermod -aG docker $USER
+mkdir -p ~/apps/ytd-kopya && cd ~/apps/ytd-kopya
+# Repo bu dizine klonlanmalı (secrets.STAGING_PROJECT_DIR burayı göstermeli)
+# .env.staging dosyasını oluştur:
+cp .env.example .env.staging
+# Değerleri düzenle (STAGING_FQDN, SECRET_KEY, vb.)
+```
+
+## 2) GitHub Secrets
+- `STAGING_SSH_HOST`
+- `STAGING_SSH_USER`
+- `STAGING_SSH_KEY` (private key)
+- `STAGING_PROJECT_DIR` (örn: `/home/ubuntu/apps/ytd-kopya`)
+
+## 3) Çalışma Mantığı
+- Push → `main` → test → iki imaj build → GHCR push → SSH ile sunucuda
+  `docker compose -f docker-compose.staging.yml up -d`.
+
+## 4) Health Endpoint’leri
+- `backend/wsgi.py` mevcut uygulamayı otomatik import etmeye çalışır:
+  `backend.app:create_app`, `backend.app:app`, `app:create_app`, `app:app`.
+- Bulamazsa geçici bir app ile `/healthz`=200, `/readiness`=503 döner.
+- Gerçek app modül yolun farklıysa `APP_IMPORT_CANDIDATES` değişkenine ekle.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,22 +1,25 @@
+# --- Builder ---
+FROM python:3.11-slim AS builder
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential curl && rm -rf /var/lib/apt/lists/*
+COPY backend/ /app/backend/
+# Opsiyonel: kökte requirements varsa da kur
+RUN python -m pip install --upgrade pip \
+ && ( [ -f /app/backend/requirements.txt ] && pip wheel -r /app/backend/requirements.txt --wheel-dir /wheels || true ) \
+ && pip wheel gunicorn flask flask-cors alembic psycopg2-binary --wheel-dir /wheels
+
+# --- Runtime ---
 FROM python:3.11-slim
 WORKDIR /app
-
-# Install dependencies
-COPY backend/requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
-# CI’da sürpriz çıkmasın diye açıkça ekle
-RUN pip install --no-cache-dir PyYAML
-
-# Copy backend and frontend code
-COPY backend ./backend
-COPY frontend ./frontend
-COPY wsgi.py ./wsgi.py
-
-# Varsayılan servis portu
-EXPOSE 5000
-# Konteyner içinden dışarıya dinleme adresi/portu
-ENV HOST=0.0.0.0
-ENV PORT=5000
-
-# Giriş noktası: wsgi.py (socketio.run host/port'u env'den okur)
-CMD ["python", "wsgi.py"]
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+RUN useradd -ms /bin/bash appuser
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache-dir /wheels/*
+COPY backend/ /app/backend/
+ENV PORT=8000
+EXPOSE 8000
+# Günlükleri JSON benzeri tek satırda tutmak için basit arglar
+ENV GUNICORN_CMD_ARGS="--bind 0.0.0.0:${PORT} --workers=${GUNICORN_WORKERS:-2} --threads=${GUNICORN_THREADS:-2} --access-logfile - --error-logfile - --timeout 120"
+USER appuser
+CMD ["bash", "-lc", "python -c 'import os,sys;print(\"APP_IMPORT_CANDIDATES=\",os.getenv(\"APP_IMPORT_CANDIDATES\"))' >/dev/null 2>&1; gunicorn backend.wsgi:app"]

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,51 @@
+name: ytd-kopya-staging
+services:
+  reverse-proxy:
+    image: caddy:2.8
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - STAGING_FQDN=${STAGING_FQDN}
+    volumes:
+      - ./infra/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_started
+
+  backend:
+    image: ghcr.io/${GITHUB_REPOSITORY}-backend:staging
+    restart: unless-stopped
+    env_file:
+      - .env.staging
+    environment:
+      - APP_IMPORT_CANDIDATES=${APP_IMPORT_CANDIDATES:-backend.app:create_app,backend.app:app,app:create_app,app:app}
+      - GUNICORN_WORKERS=4
+      - GUNICORN_THREADS=4
+      - PORT=8000
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8000/healthz || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+    networks:
+      - web
+
+  frontend:
+    image: ghcr.io/${GITHUB_REPOSITORY}-frontend:staging
+    restart: unless-stopped
+    networks:
+      - web
+
+networks:
+  web:
+    driver: bridge
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+# Statik SPA (Vite/CRA) için çok aşamalı build. Next.js SSR ise ayrı runtime gerekir.
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY frontend/package*.json ./
+RUN npm ci --ignore-scripts
+COPY frontend/ ./
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+HEALTHCHECK --interval=15s --timeout=3s --retries=10 CMD wget -qO- http://127.0.0.1/ >/dev/null || exit 1
+CMD ["nginx","-g","daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,15 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Basit güvenlik başlıkları (proxy tarafında daha katı CSP var)
+  add_header X-Content-Type-Options nosniff;
+  add_header X-Frame-Options DENY;
+  add_header Referrer-Policy no-referrer-when-downgrade;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,0 +1,29 @@
+{
+    email admin@example.com
+    # Daha katı TLS ve log ayarları burada genişletilebilir
+}
+
+${STAGING_FQDN} {
+    encode gzip
+
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        Referrer-Policy "no-referrer-when-downgrade"
+        # Basit bir CSP iskeleti (frontend statik ise rahat çalışır)
+        Content-Security-Policy "default-src 'self'; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https: wss:"
+    }
+
+    @api path /healthz /readiness /api* /ws*
+    handle @api {
+        reverse_proxy backend:8000
+    }
+
+    handle {
+        root * /usr/share/nginx/html
+        file_server
+        try_files {path} /index.html
+        reverse_proxy frontend:80
+    }
+}


### PR DESCRIPTION
## Summary
- add staging CI/CD workflow for backend and frontend builds
- introduce Dockerfiles, docker-compose and Caddy config for staging environment
- implement dynamic backend wsgi loader with health endpoints and update env example
- consolidate .env.example to include both application and staging/infra variables
- improve staging workflow tests with Postgres/Redis services and optional frontend build
- point backend Dockerfile to backend.wsgi app

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_689a5f74126c832fad40302406ab787b