### PR TITLE
Implement usage-based limit service

### DIFF
--- a/backend/services/limit_service.py
+++ b/backend/services/limit_service.py
@@ -1,18 +1,54 @@
 """Kullanıcı limit servisleri."""
 
+from datetime import datetime
+from sqlalchemy import func
+
+from backend import db
+from backend.db.models import UsageLog, User
+
 
 def get_user_limits(user_id: int) -> dict:
-    """
-    Belirli bir kullanıcının plan ve limit bilgilerini döndür.
-    Gelecekte DB sorguları ile genişletilebilir; şimdilik mock veri döndürür.
-    """
+    """Belirli bir kullanıcının plan ve limit bilgilerini döndür."""
 
-    # TODO: Veritabanı entegrasyonu yapılacak.
+    user: User | None = User.query.get(user_id)
+    if not user or not user.plan:
+        return {"plan": None, "limits": {}}
+
+    plan_name = user.plan.name
+    features = user.plan.features_dict()
+
+    daily_max = features.get("api_request_daily", 0)
+    monthly_max = features.get("api_request_monthly", 0)
+
+    now = datetime.utcnow()
+    start_of_day = datetime(now.year, now.month, now.day)
+    start_of_month = datetime(now.year, now.month, 1)
+
+    daily_used = (
+        db.session.query(func.count(UsageLog.id))
+        .filter(
+            UsageLog.user_id == user_id,
+            UsageLog.action == "api_request",
+            UsageLog.timestamp >= start_of_day,
+        )
+        .scalar()
+    )
+
+    monthly_used = (
+        db.session.query(func.count(UsageLog.id))
+        .filter(
+            UsageLog.user_id == user_id,
+            UsageLog.action == "api_request",
+            UsageLog.timestamp >= start_of_month,
+        )
+        .scalar()
+    )
+
     return {
-        "plan": "premium",
+        "plan": plan_name,
         "limits": {
-            "daily_requests": {"used": 45, "max": 100},
-            "monthly_requests": {"used": 1200, "max": 3000},
+            "daily_requests": {"used": daily_used, "max": daily_max},
+            "monthly_requests": {"used": monthly_used, "max": monthly_max},
         },
     }
 


### PR DESCRIPTION
## Summary
- compute user API request limits from plan features and usage logs
- test limit status endpoint with UsageLog records

## Testing
- `pytest tests/test_limit_status_api.py`

------
https://chatgpt.com/codex/tasks/task_e_689b93a012e0832fa517a4bd6d44b294