### PR TITLE
Add LimitStatus component to dashboard

### DIFF
--- a/frontend/react/dashboard/Dashboard.tsx
+++ b/frontend/react/dashboard/Dashboard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card, CardContent } from '../components/ui/card';
 import { BarChart } from 'lucide-react';
 import PlanLimitCard from '../PlanLimitCard';
+import LimitStatus from '../components/LimitStatus';
 
 export default function Dashboard() {
   return (
@@ -10,6 +11,9 @@ export default function Dashboard() {
 
       {/* Kullanım limitleri */}
       <PlanLimitCard />
+
+      {/* Kullanım limitleri bileşeni */}
+      <LimitStatus />
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <Card>


### PR DESCRIPTION
## Summary
- show detailed usage limits on dashboard via LimitStatus component

## Testing
- `pytest` (failed: assert 403 == 200)
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ba2cf9cd8832fac37ec2ce07fab63