### PR TITLE
Refactor PlanLimitCard fetch and update tests

### DIFF
--- a/frontend/tests/Dashboard.test.tsx
+++ b/frontend/tests/Dashboard.test.tsx
@@ -9,7 +9,8 @@ beforeEach(() => {
       ok: true,
       json: () =>
         Promise.resolve({
-          limits: { test_feature: { limit: 5, used: 2, remaining: 3, percent_used: 40 } },
+          plan: null,
+          limits: { test_feature: { used: 2, max: 5 } },
         }),
     })
   ) as any;
@@ -18,5 +19,6 @@ beforeEach(() => {
 
 test('renders limit info inside dashboard', async () => {
   render(<Dashboard />);
-  expect(await screen.findByText('Kullanım: 2 / 5')).toBeInTheDocument();
+  const els = await screen.findAllByText('2 / 5 (40%)');
+  expect(els.length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- fetch plan limits from backend and render progress with warnings
- adjust dashboard and card tests to new limit format

## Testing
- `npm test`
- `pytest` (fails: tests/test_limit_status_api.py::test_limit_status_endpoint - assert 403 == 200)

------
https://chatgpt.com/codex/tasks/task_e_689ba565e678832fb13a21b5e6bdf42e