### PR TITLE
feat: return user custom features in limits

### DIFF
--- a/tests/test_limit_status_api.py
+++ b/tests/test_limit_status_api.py
@@ -85,6 +85,8 @@ def test_limit_status_endpoint(test_app, test_user):
     assert "reset_at" in data
     reset_at = datetime.fromisoformat(data["reset_at"])
     assert reset_at > datetime.utcnow()
+    assert "custom_features" in data
+    assert isinstance(data["custom_features"], dict)
     log = Log.query.filter_by(action="limit_status").first()
     assert log is not None
     assert log.user_id == str(test_user.id)


### PR DESCRIPTION
## Summary
- include user's custom_features in limits status response
- test custom_features presence in limit status API

## Testing
- `pytest tests/test_limit_status_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cc6357db4832f910d977b90fd7422