### PR TITLE
feat(frontend): display custom feature hints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,13 +16,20 @@ Returns the current user's subscription plan and usage limits.
     "daily_requests": {"used": 45, "max": 100, "percent": 45},
     "monthly_requests": {"used": 1200, "max": 3000, "percent": 40}
   },
-  "reset_at": "2025-02-01T00:00:00"
+  "reset_at": "2025-02-01T00:00:00",
+
+  "custom_features": {
+    "beta_mode": true,
+    "extra_quota": 250
+  }
 }
 ```
 ### Notes
 - `reset_at`: ISO-8601 UTC timestamp for when monthly limits reset.
-- Reset day is configurable via environment variable `LIMITS_RESET_DAY` (1–28).  
+- Reset day is configurable via environment variable `LIMITS_RESET_DAY` (1–28).
   If not set, it defaults to the 1st day of each month.
+- `custom_features`: Optional per-user overrides/feature flags (object). Values may be booleans,
+  numbers or strings. Clients should display them as read-only hints.
 
 ### Error Responses
 - **401 Unauthorized**: `{ "error": "Kullanıcı bulunamadı." }`

--- a/frontend/react/PlanLimitCard.tsx
+++ b/frontend/react/PlanLimitCard.tsx
@@ -10,6 +10,7 @@ interface LimitData {
   plan: string | null;
   limits: Record<string, LimitInfo>;
   reset_at?: string | null; // ISO tarih formatında limit reset zamanı
+  custom_features?: Record<string, unknown>;
 }
 
 interface LimitItem {
@@ -72,6 +73,13 @@ export default function PlanLimitCard() {
       return { key, label: key, used, max, pct };
     });
   }, [data]);
+
+  const customEntries = useMemo(() => {
+    if (!data?.custom_features) return [];
+    try {
+      return Object.entries(data.custom_features);
+    } catch { return []; }
+  }, [data?.custom_features]);
 
   const resetInfo = useMemo(() => {
     if (!data?.reset_at) return null;
@@ -149,6 +157,23 @@ export default function PlanLimitCard() {
                 </div>
               ))}
             </div>
+
+            {/* Özel özellikler (custom_features) */}
+            <div className="mt-5">
+              <div className="text-sm text-muted-foreground">Özel Özellikler</div>
+              {customEntries.length === 0 ? (
+                <div className="text-xs opacity-70 mt-1">Tanımlı özel özellik yok.</div>
+              ) : (
+                <ul className="mt-2 grid gap-2 md:grid-cols-2">
+                  {customEntries.map(([k, v]) => (
+                    <li key={String(k)} className="flex items-center justify-between text-xs">
+                      <span className="font-medium">{labelize(String(k))}</span>
+                      <span className="opacity-80">{formatValue(v)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
           </>
         )}
       </CardContent>
@@ -159,4 +184,13 @@ export default function PlanLimitCard() {
 function labelize(raw: string) {
   const s = String(raw || '').replace(/_/g, ' ').trim();
   return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function formatValue(v: unknown): string {
+  if (v === null || v === undefined) return '-';
+  if (typeof v === 'boolean') return v ? 'Açık' : 'Kapalı';
+  if (typeof v === 'object') {
+    try { return JSON.stringify(v); } catch { return '[obj]'; }
+  }
+  return String(v);
 }

--- a/frontend/tests/PlanLimitCard.test.tsx
+++ b/frontend/tests/PlanLimitCard.test.tsx
@@ -9,8 +9,13 @@ beforeEach(() => {
       ok: true,
       json: () =>
         Promise.resolve({
-          plan: null,
+          plan: "basic",
+          reset_at: "2099-01-01T00:00:00Z",
           limits: { test_feature: { used: 2, max: 5 } },
+          custom_features: {
+            beta_mode: true,
+            extra_quota: 50
+          },
         }),
     })
   ) as any;
@@ -21,6 +26,10 @@ test('renders limit info after load', async () => {
   render(<PlanLimitCard />);
   expect(await screen.findByText('2 / 5 (40%)')).toBeInTheDocument();
   expect(screen.getByTestId('progress')).toHaveStyle({ width: '40%' });
+  // custom_features görünür olmalı
+  expect(await screen.findByText('Özel Özellikler')).toBeInTheDocument();
+  expect(screen.getByText('Beta mode')).toBeInTheDocument();
+  expect(screen.getByText('Açık')).toBeInTheDocument();
 });
 
 test('shows warning text at 90 percent usage', async () => {
@@ -29,8 +38,9 @@ test('shows warning text at 90 percent usage', async () => {
       ok: true,
       json: () =>
         Promise.resolve({
-          plan: null,
+          plan: "basic",
           limits: { warn: { used: 9, max: 10 } },
+          custom_features: {}
         }),
     })
   );
@@ -45,8 +55,9 @@ test('shows error text at full usage', async () => {
       ok: true,
       json: () =>
         Promise.resolve({
-          plan: null,
+          plan: "basic",
           limits: { full: { used: 10, max: 10 } },
+          custom_features: {}
         }),
     })
   );


### PR DESCRIPTION
## Summary
- document `custom_features` in limits API
- show custom features in PlanLimitCard
- test custom feature rendering

## Testing
- `npm test -- tests/PlanLimitCard.test.tsx`
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_689cc90e1708832f91301d4d44321ad3