### PR TITLE
feat(frontend): add admin custom features editor

### DIFF
--- a/frontend/react/admin/CustomFeaturesEditor.tsx
+++ b/frontend/react/admin/CustomFeaturesEditor.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+// Anahtar-değer çifti tipi
+type KV = [string, string];
+
+/**
+ * Admin panelinde kullanıcı özel özelliklerini düzenlemek için basit editör.
+ *
+ * Props:
+ * - userId: Özellikleri düzenlenecek kullanıcının ID'si
+ * - tokenProvider: Opsiyonel token sağlayıcı (JWT ya da API key)
+ */
+export default function CustomFeaturesEditor({
+  userId,
+  tokenProvider,
+}: {
+  userId: number | string;
+  tokenProvider?: () => string | null; // JWT veya API key için opsiyonel sağlayıcı
+}) {
+  // Satırlar [key, value] olarak tutulur
+  const [items, setItems] = useState<KV[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // API çağrıları için gerekli header'ları hazırla
+  const headers = useMemo(() => {
+    const h: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-CSRF-TOKEN": "admin",
+    };
+    const token = tokenProvider?.() ?? localStorage.getItem("access_token");
+    const apiKey = localStorage.getItem("api_key");
+    if (token) h["Authorization"] = `Bearer ${token}`;
+    if (apiKey) h["X-API-KEY"] = apiKey;
+    return h;
+  }, [tokenProvider]);
+
+  // İlk yüklemede kullanıcının özelliklerini getir
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/admin/users/${userId}/custom_features`, {
+          method: "GET",
+          headers,
+          credentials: "include",
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        const cf = data?.custom_features ?? {};
+        if (!mounted) return;
+        // Gelen nesneyi anahtar-değer listesine çevir
+        const kv = Object.entries(cf).map(
+          ([k, v]) => [k, normalizeValue(v)] as KV
+        );
+        setItems(kv.length ? kv : [["", ""]]);
+      } catch (e: any) {
+        if (mounted) setError(e?.message || "Yüklenemedi");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [userId, headers]);
+
+  // Değerleri string'e dönüştür
+  function normalizeValue(v: unknown): string {
+    if (v === null || v === undefined) return "";
+    if (typeof v === "object") {
+      try {
+        return JSON.stringify(v);
+      } catch {
+        return String(v);
+      }
+    }
+    return String(v);
+  }
+
+  // Yeni satır ekle
+  function onAdd() {
+    setItems((prev) => [...prev, ["", ""]]);
+  }
+
+  // Satır sil
+  function onRemove(idx: number) {
+    setItems((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  // Hücre değişikliklerini işle
+  function onChange(idx: number, which: "k" | "v", value: string) {
+    setItems((prev) =>
+      prev.map((row, i) =>
+        i === idx ? (which === "k" ? [value, row[1]] : [row[0], value]) : row
+      )
+    );
+  }
+
+  // String'i uygun tipte değere çevir
+  function parseTyped(val: string): unknown {
+    const v = val.trim();
+    if (v === "") return "";
+    if (v === "true") return true;
+    if (v === "false") return false;
+    if (!Number.isNaN(Number(v)) && /^\d+(\.\d+)?$/.test(v)) {
+      return Number(v);
+    }
+    // JSON objesi dene
+    try {
+      const obj = JSON.parse(v);
+      return obj;
+    } catch {
+      return v;
+    }
+  }
+
+  // Kaydet butonu tıklandığında çalışır
+  async function onSave() {
+    setError(null);
+    try {
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of items) {
+        if (!k.trim()) continue;
+        body[k.trim()] = parseTyped(v);
+      }
+      const res = await fetch(`/api/admin/users/${userId}/custom_features`, {
+        method: "PUT",
+        headers,
+        credentials: "include",
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const t = await res.text();
+        throw new Error(`Kaydedilemedi: ${res.status} ${t || ""}`.trim());
+      }
+    } catch (e: any) {
+      setError(e?.message || "Kaydedilemedi");
+      return;
+    }
+    // Basit kullanıcı bildirimi
+    alert("Kaydedildi");
+  }
+
+  return (
+    <div className="border rounded-lg p-4">
+      <div className="text-base font-semibold mb-2">Özel Özellikler</div>
+      {loading && <div>Yükleniyor…</div>}
+      {error && <div className="text-red-600 text-sm mb-2">{error}</div>}
+      {!loading && (
+        <>
+          <div className="space-y-2">
+            {items.map(([k, v], idx) => (
+              <div key={idx} className="grid grid-cols-12 gap-2 items-center">
+                <input
+                  className="col-span-5 border rounded px-2 py-1 text-sm"
+                  placeholder="anahtar (örn: beta_mode)"
+                  value={k}
+                  onChange={(e) => onChange(idx, "k", e.target.value)}
+                />
+                <input
+                  className="col-span-6 border rounded px-2 py-1 text-sm"
+                  placeholder='değer (örn: true, 50, "gold")'
+                  value={v}
+                  onChange={(e) => onChange(idx, "v", e.target.value)}
+                />
+                <button
+                  type="button"
+                  className="col-span-1 text-xs border rounded px-2 py-1"
+                  onClick={() => onRemove(idx)}
+                  aria-label={`remove-row-${idx}`}
+                >
+                  Sil
+                </button>
+              </div>
+            ))}
+          </div>
+          <div className="flex gap-2 mt-3">
+            <button
+              type="button"
+              className="border rounded px-3 py-1 text-sm"
+              onClick={onAdd}
+            >
+              Satır Ekle
+            </button>
+            <button
+              type="button"
+              className="border rounded px-3 py-1 text-sm"
+              onClick={onSave}
+            >
+              Kaydet
+            </button>
+          </div>
+          <div className="text-xs text-muted-foreground mt-3">
+            Metin dışı değerler için JSON da yazabilirsiniz. Örn: <code>{"{\"limits\":{\"pro\":true}}"}</code>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/tests/CustomFeaturesEditor.test.tsx
+++ b/frontend/tests/CustomFeaturesEditor.test.tsx
@@ -1,32 +1,143 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import '@testing-library/jest-dom';
-import CustomFeaturesEditor from '../react/CustomFeaturesEditor';
+import CustomFeaturesEditor from '../react/admin/CustomFeaturesEditor';
 
 describe('CustomFeaturesEditor', () => {
   beforeEach(() => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve([
-          { id: 1, username: 'test', subscription_level: 'basic', custom_features: '{}' }
-        ])
-      })
-    ) as any;
+    window.alert = jest.fn();
   });
 
-  it('renders without crashing', async () => {
-    render(<CustomFeaturesEditor />);
-    expect(await screen.findByText('Kullanıcıya Özel Özellikler')).toBeInTheDocument();
+  it('fetches and renders', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ custom_features: { test: '1' } }),
+    });
+    global.fetch = fetchMock as any;
+
+    render(<CustomFeaturesEditor userId={1} />);
+
+    expect(await screen.findByText('Özel Özellikler')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/admin/users/1/custom_features',
+      expect.objectContaining({ method: 'GET' })
+    );
   });
 
-  it.skip('displays error on invalid JSON', async () => {
-    render(<CustomFeaturesEditor />);
-    const select = await screen.findByRole('combobox');
-    fireEvent.change(select, { target: { value: '1' } });
-    const input = screen.getByLabelText(/custom_features JSON/i);
-    fireEvent.change(input, { target: { value: '{invalid json' } });
-    fireEvent.click(screen.getByText('Kaydet'));
-    expect(await screen.findByText(/geçersiz json/i)).toBeInTheDocument();
+  it('saves non-empty fields with typed values and alerts on success', async () => {
+    const fetchMock = jest.fn().mockImplementation((url, opts) => {
+      if (!opts || opts.method === 'GET') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ custom_features: {} }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+    global.fetch = fetchMock as any;
+
+    render(<CustomFeaturesEditor userId={1} />);
+
+    await screen.findByPlaceholderText('anahtar (örn: beta_mode)');
+
+    const addBtn = await screen.findByRole('button', { name: 'Satır Ekle' });
+    for (let i = 0; i < 4; i++) {
+      await userEvent.click(addBtn);
+    }
+
+    const keyInputs = screen.getAllByPlaceholderText('anahtar (örn: beta_mode)');
+    const valueInputs = screen.getAllByPlaceholderText(
+      'değer (örn: true, 50, "gold")'
+    );
+
+    await userEvent.type(keyInputs[0], 'beta_mode');
+    await userEvent.type(valueInputs[0], 'true');
+
+    await userEvent.type(keyInputs[1], 'limit');
+    await userEvent.type(valueInputs[1], '50');
+
+    await userEvent.type(keyInputs[2], 'prefs');
+    fireEvent.change(valueInputs[2], { target: { value: '{"gold":true}' } });
+
+    await userEvent.type(valueInputs[3], 'skip');
+
+    await userEvent.type(keyInputs[4], 'bad');
+    fireEvent.change(valueInputs[4], { target: { value: '{"broken"}' } });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Kaydet' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const putCall = fetchMock.mock.calls[1];
+    expect(putCall[0]).toBe('/api/admin/users/1/custom_features');
+    const sentBody = JSON.parse(putCall[1].body);
+    expect(sentBody).toEqual({
+      beta_mode: true,
+      limit: 50,
+      prefs: { gold: true },
+      bad: '{"broken"}',
+    });
+    expect(window.alert).toHaveBeenCalledWith('Kaydedildi');
+  });
+
+  it('shows error when save request rejects', async () => {
+    const fetchMock = jest.fn().mockImplementation((url, opts) => {
+      if (!opts || opts.method === 'GET') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ custom_features: {} }),
+        });
+      }
+      return Promise.reject(new Error('fail'));
+    });
+    global.fetch = fetchMock as any;
+
+    render(<CustomFeaturesEditor userId={1} />);
+    await screen.findByPlaceholderText('anahtar (örn: beta_mode)');
+
+    const keyInput = screen.getByPlaceholderText('anahtar (örn: beta_mode)');
+    const valueInput = screen.getByPlaceholderText('değer (örn: true, 50, "gold")');
+
+    await userEvent.type(keyInput, 'a');
+    await userEvent.type(valueInput, '1');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Kaydet' }));
+
+    expect(await screen.findByText('fail')).toBeInTheDocument();
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  it('shows error when save response is not ok', async () => {
+    const fetchMock = jest.fn().mockImplementation((url, opts) => {
+      if (!opts || opts.method === 'GET') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ custom_features: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 500,
+        text: async () => 'bad',
+      });
+    });
+    global.fetch = fetchMock as any;
+
+    render(<CustomFeaturesEditor userId={1} />);
+    await screen.findByPlaceholderText('anahtar (örn: beta_mode)');
+
+    const keyInput = screen.getByPlaceholderText('anahtar (örn: beta_mode)');
+    const valueInput = screen.getByPlaceholderText('değer (örn: true, 50, "gold")');
+
+    await userEvent.type(keyInput, 'a');
+    await userEvent.type(valueInput, '1');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Kaydet' }));
+
+    expect(
+      await screen.findByText('Kaydedilemedi: 500 bad')
+    ).toBeInTheDocument();
+    expect(window.alert).not.toHaveBeenCalled();
   });
 });
+


### PR DESCRIPTION
## Summary
- add admin component to manage user custom features
- test fetching, saving, and error handling for custom feature editor

## Testing
- `npm test -- tests/CustomFeaturesEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cd24d6394832f82a14929e700a113