### PR TITLE
feat(admin): add user detail page

### DIFF
--- a/frontend/react/admin/UserDetail.tsx
+++ b/frontend/react/admin/UserDetail.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import CustomFeaturesEditor from "./CustomFeaturesEditor";
+
+/**
+ * Admin Kullanıcı Detay Sayfası
+ * - Kullanıcıya ait custom_features alanını düzenlemek için CustomFeaturesEditor içerir.
+ *
+ * Not: Bu bileşen router ile /admin/users/:id gibi bir route'a bağlanacaksa,
+ *      userId parametresini route params'tan çekip bu bileşene prop olarak geçin.
+ */
+export default function UserDetail({
+  userId,
+  tokenProvider,
+}: {
+  userId: number | string;
+  tokenProvider?: () => string | null;
+}) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-xl font-semibold">Kullanıcı Detayı</h1>
+        <div className="text-sm text-muted-foreground">Kullanıcı ID: {String(userId)}</div>
+      </div>
+      <CustomFeaturesEditor userId={userId} tokenProvider={tokenProvider} />
+    </div>
+  );
+}

--- a/frontend/tests/AdminUserDetail.test.tsx
+++ b/frontend/tests/AdminUserDetail.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import "@testing-library/jest-dom";
+import UserDetail from "../react/admin/UserDetail";
+
+beforeEach(() => {
+  // CustomFeaturesEditor içindeki GET çağrısını karşılamak için mock
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ custom_features: { beta_mode: true } }),
+    } as any)
+  ) as any;
+  Storage.prototype.getItem = jest.fn(() => "token");
+});
+
+test("renders user detail and loads CustomFeaturesEditor", async () => {
+  render(<UserDetail userId={42} />);
+  expect(await screen.findByText("Kullanıcı Detayı")).toBeInTheDocument();
+  expect(screen.getByText("Kullanıcı ID: 42")).toBeInTheDocument();
+  // CustomFeaturesEditor başlığı
+  expect(await screen.findByText("Özel Özellikler")).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add admin user detail page to edit custom features
- cover user detail with tests

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_689ce59b089c832fa70772b1370e2c83