### PR TITLE
Add admin user detail route

### DIFF
--- a/frontend/react/AdminRoutes.tsx
+++ b/frontend/react/AdminRoutes.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router-dom';
 import AdminDashboard from './pages/AdminDashboard';
 import AdminUsers from './pages/AdminUsers';
 import AdminPromos from './pages/AdminPromos';
@@ -10,12 +10,14 @@ import AdminContent from './pages/AdminContent';
 import AdminMonitoring from './pages/AdminMonitoring';
 import AdminLogs from './pages/AdminLogs';
 import AdminFeatureFlags from './pages/AdminFeatureFlags';
+import UserDetail from './admin/UserDetail';
 
 const AdminRoutes = () => {
   return (
     <Routes>
       <Route path="/admin" element={<AdminDashboard />} />
       <Route path="/admin/users" element={<AdminUsers />} />
+      <Route path="/admin/users/:id" element={<AdminUserDetailRoute />} />
       <Route path="/admin/promos" element={<AdminPromos />} />
       <Route path="/admin/predictions" element={<AdminPredictions />} />
       <Route path="/admin/plans" element={<AdminPlanManager />} />
@@ -27,5 +29,11 @@ const AdminRoutes = () => {
     </Routes>
   );
 };
+
+// Route bileşeni, URL parametresinden kullanıcı ID'sini alır
+function AdminUserDetailRoute() {
+  const { id } = useParams<{ id: string }>();
+  return <UserDetail userId={id!} />;
+}
 
 export default AdminRoutes;

--- a/frontend/tests/AdminUserDetail.test.tsx
+++ b/frontend/tests/AdminUserDetail.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import "@testing-library/jest-dom";
-import UserDetail from "../react/admin/UserDetail";
+import { MemoryRouter } from "react-router-dom";
+import AdminRoutes from "../react/AdminRoutes";
 
 beforeEach(() => {
   // CustomFeaturesEditor içindeki GET çağrısını karşılamak için mock
@@ -15,7 +16,11 @@ beforeEach(() => {
 });
 
 test("renders user detail and loads CustomFeaturesEditor", async () => {
-  render(<UserDetail userId={42} />);
+  render(
+    <MemoryRouter initialEntries={["/admin/users/42"]}>
+      <AdminRoutes />
+    </MemoryRouter>
+  );
   expect(await screen.findByText("Kullanıcı Detayı")).toBeInTheDocument();
   expect(screen.getByText("Kullanıcı ID: 42")).toBeInTheDocument();
   // CustomFeaturesEditor başlığı


### PR DESCRIPTION
## Summary
- expand admin routing with user detail path
- test admin user detail route renders via URL

## Testing
- `npm test`
- `pytest` *(fails: DetachedInstanceError in limit status tests)*

------
https://chatgpt.com/codex/tasks/task_e_689ceadda8a4832fbba957dd9355ec90