### PR TITLE
Integrate DRAKS decision engine blueprint

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -284,6 +284,13 @@ def create_app() -> Flask:
     app.register_blueprint(subscriptions_bp)
     app.register_blueprint(limits_bp)
 
+    # --- DRAKS Karar Motoru blueprint ---
+    try:
+        from backend.draks import draks_bp
+        app.register_blueprint(draks_bp)
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"DRAKS blueprint yüklenemedi: {e}")
+
     # Health
     @app.route("/health", methods=["GET"])
     def health_check():

--- a/backend/draks/__init__.py
+++ b/backend/draks/__init__.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+# /api/draks altında karar motoru uçları
+draks_bp = Blueprint("draks", __name__, url_prefix="/api/draks")
+
+# Rotaları yükle
+from . import routes  # noqa: E402,F401

--- a/backend/draks/engine_min.py
+++ b/backend/draks/engine_min.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+import numpy as np, pandas as pd
+
+
+def compute_features(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.copy().astype(float)
+    out["ema20"] = out["close"].ewm(span=20, adjust=False).mean()
+    out["ema50"] = out["close"].ewm(span=50, adjust=False).mean()
+    ema12 = out["close"].ewm(span=12, adjust=False).mean()
+    ema26 = out["close"].ewm(span=26, adjust=False).mean()
+    out["macd"] = ema12 - ema26
+    out["macd_sig"] = out["macd"].ewm(span=9, adjust=False).mean()
+    out["macd_hist"] = out["macd"] - out["macd_sig"]
+    delta = out["close"].diff()
+    gain = (delta.clip(lower=0)).ewm(alpha=1 / 14, adjust=False).mean()
+    loss = (-delta.clip(upper=0)).ewm(alpha=1 / 14, adjust=False).mean()
+    rs = gain / (loss + 1e-12)
+    out["rsi14"] = 100 - (100 / (1 + rs))
+    bb_p = 20
+    bb_k = 2.0
+    ma = out["close"].rolling(bb_p).mean()
+    sd = out["close"].rolling(bb_p).std(ddof=0)
+    out["bb_mid"], out["bb_up"], out["bb_dn"] = ma, ma + bb_k * sd, ma - bb_k * sd
+    out["bb_width"] = (out["bb_up"] - out["bb_dn"]) / out["close"]
+    prev_c = out["close"].shift(1)
+    tr = pd.concat(
+        [
+            out["high"] - out["low"],
+            (out["high"] - prev_c).abs(),
+            (out["low"] - prev_c).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+    out["atr"] = tr.rolling(14).mean()
+    return out.dropna()
+
+
+class RegimeHMM:
+    states = ("bull", "bear", "volatile", "range")
+
+    def probs(self, last: pd.Series) -> Dict[str, float]:
+        ema_spread = float((last["ema20"] - last["ema50"]) / (last["close"] + 1e-12))
+        vola = float(last["atr"] / (last["close"] + 1e-12))
+        bbw = float(last["bb_width"])
+        s_bull = max(0.0, ema_spread)
+        s_bear = max(0.0, -ema_spread)
+        s_vol = max(0.0, vola - 0.02) + max(0.0, bbw - 0.04)
+        s_rng = max(0.0, 0.04 - bbw)
+        z = np.array([s_bull, s_bear, s_vol, s_rng]) + 1e-6
+        z = z / z.sum()
+        return dict(zip(self.states, z.tolist()))
+
+
+@dataclass
+class ModuleOutput:
+    module: str
+    direction: int
+    edge: float
+    prob: float
+    horizon_days: int
+    reasons: List[str]
+    meta: Dict
+
+
+def trend_module(
+    df: pd.DataFrame, rp: Dict[str, float], params: Dict, cost_bps: int = 6
+) -> Optional[ModuleOutput]:
+    row = df.iloc[-1]
+    spread = row["ema20"] - row["ema50"]
+    direction = 1 if spread > 0 else (-1 if spread < 0 else 0)
+    slope = (df["ema20"].iloc[-1] - df["ema20"].iloc[-5]) / 5
+    prob = float(
+        min(
+            0.9,
+            0.55
+            + 0.20 * abs(spread / row["close"])
+            + 0.10 * np.sign(direction) * np.sign(slope),
+        )
+    )
+    gross_edge = abs(spread) / row["close"] * 0.8
+    net_edge = float(gross_edge - cost_bps * 1e-4)
+    return ModuleOutput(
+        "trend", direction, max(0.0, net_edge), prob, 15, ["EMA20-EMA50", "slope"], {"rp": rp}
+    )
+
+
+def momentum_module(
+    df: pd.DataFrame, rp: Dict[str, float], params: Dict, cost_bps: int = 6
+) -> Optional[ModuleOutput]:
+    row = df.iloc[-1]
+    rsi = row["rsi14"]
+    hist = row["macd_hist"]
+    direction = 1 if (rsi > 50 and hist > 0) else (-1 if (rsi < 50 and hist < 0) else 0)
+    prob = float(min(0.9, 0.50 + 0.25 * abs(hist) + 0.25 * abs(rsi - 50) / 50))
+    gross_edge = (abs(hist) / (df["close"].rolling(26).std().iloc[-1] + 1e-8)) * 0.5
+    net_edge = float(gross_edge - cost_bps * 1e-4)
+    return ModuleOutput(
+        "momentum", direction, max(0.0, net_edge), prob, 10, ["RSI", "MACD_hist"], {}
+    )
+
+
+def meanrev_module(
+    df: pd.DataFrame, rp: Dict[str, float], params: Dict, cost_bps: int = 6
+) -> Optional[ModuleOutput]:
+    row = df.iloc[-1]
+    z = (row["close"] - row["bb_mid"]) / ((row["bb_up"] - row["bb_mid"]) + 1e-8)
+    direction = -1 if z > 1 else (1 if z < -1 else 0)
+    prob = float(min(0.9, 0.5 + 0.3 * abs(z)))
+    gross_edge = float(min(0.03, 0.5 * abs(z)))
+    net_edge = float(max(0.0, gross_edge - cost_bps * 1e-4))
+    return ModuleOutput("meanrev", direction, net_edge, prob, 7, ["BB_zscore"], {"z": float(z)})
+
+
+class LinUCB:
+    def __init__(self, d: int, alpha: float = 0.5, ridge: float = 1e-3):
+        self.alpha = alpha
+        import numpy as _np
+
+        self.A = _np.eye(d) * ridge
+        self.b = _np.zeros((d, 1))
+
+    def weight(self, x: np.ndarray) -> Tuple[float, np.ndarray]:
+        x = x.reshape(-1, 1)
+        A_inv = np.linalg.pinv(self.A)
+        theta = A_inv @ self.b
+        mu = float((x.T @ theta).ravel())
+        ucb = self.alpha * float(np.sqrt((x.T @ A_inv @ x).ravel()))
+        return mu + ucb, theta.ravel()
+
+    def update(self, x: np.ndarray, reward: float):
+        x = x.reshape(-1, 1)
+        self.A += x @ x.T
+        self.b += reward * x
+
+
+class Calibrator:
+    def predict(self, y_raw: float) -> float:
+        return float(max(0.0, min(1.0, y_raw)))
+
+
+from collections import deque
+
+
+class ConformalGate:
+    def __init__(self, target_err: float = 0.10, window: int = 500):
+        self.delta = target_err
+        self.residuals = deque(maxlen=window)
+
+    def thresholds(self) -> Tuple[float, float]:
+        if len(self.residuals) < 50:
+            return 0.02, -0.02
+        q = float(np.quantile(np.array(self.residuals), 1 - self.delta))
+        return q, -q
+
+    def update(self, residual: float):
+        self.residuals.append(float(residual))
+
+
+def position_size(
+    S: float,
+    atr: float,
+    price: float,
+    target_vol: float = 0.02,
+    maxRisk: float = 0.02,
+    kelly_clip: float = 0.4,
+    p: Optional[float] = None,
+    b: Optional[float] = None,
+) -> float:
+    realized_vol = max(1e-8, atr / (price + 1e-8))
+    conf_adj = 0.8 + 0.4 * min(abs(S), 1.0)
+    vola_part = min(maxRisk, target_vol / realized_vol) * conf_adj
+    kelly = 0.0
+    if p is not None and b is not None and b > 0:
+        kelly = max(0.0, min(kelly_clip, (p * b - (1 - p)) / b))
+    return float(min(maxRisk, vola_part + kelly * maxRisk))
+
+
+class DRAKSEngine:
+    def __init__(self, cfg: Dict):
+        self.cfg = cfg
+        self.regime = RegimeHMM()
+        self.conformal = ConformalGate(
+            cfg.get("thresholds", {}).get("target_error_rate", 0.10)
+        )
+        self.calibrators: Dict[str, Calibrator] = {}
+        self.bandits: Dict[str, LinUCB] = {}
+
+    def context_vec(self, df: pd.DataFrame, rp: Dict[str, float]) -> np.ndarray:
+        row = df.iloc[-1]
+        vola = float(row["atr"] / (row["close"] + 1e-8))
+        bbw = float(row["bb_width"])
+        return np.array(
+            [
+                rp.get("bull", 0),
+                rp.get("bear", 0),
+                rp.get("volatile", 0),
+                rp.get("range", 0),
+                vola,
+                bbw,
+            ],
+            dtype=float,
+        )
+
+    def _bandit_score(self, module: str, x: np.ndarray) -> float:
+        b = self.bandits.setdefault(
+            module,
+            LinUCB(
+                d=len(x),
+                alpha=self.cfg.get("bandit", {}).get("alpha", 0.5),
+                ridge=self.cfg.get("bandit", {}).get("ridge", 1e-3),
+            ),
+        )
+        score, _ = b.weight(x)
+        return float(score)
+
+    def run(self, raw_df: pd.DataFrame, symbol: str) -> Dict:
+        df = compute_features(raw_df)
+        row = df.iloc[-1]
+        rp = self.regime.probs(row)
+        outputs: List[Tuple[str, ModuleOutput, float]] = []
+        for name, fn in [
+            ("trend", trend_module),
+            ("momentum", momentum_module),
+            ("meanrev", meanrev_module),
+        ]:
+            out = fn(df, rp, params={}, cost_bps=self.cfg.get("cost_bps", 6))
+            if not out:
+                continue
+            cal = self.calibrators.setdefault(name, Calibrator())
+            prob_cal = cal.predict(out.prob)
+            outputs.append((name, out, prob_cal))
+        x = self.context_vec(df, rp)
+        logits = {name: self._bandit_score(name, x) for name, _, _ in outputs}
+        if not logits:
+            return {"symbol": symbol, "decision": "HOLD", "score": 0.0}
+        z = np.array(list(logits.values()))
+        w = np.exp(z - z.max())
+        w = w / w.sum() if w.sum() > 0 else np.ones_like(z) / len(z)
+        weights = {list(logits.keys())[i]: float(w[i]) for i in range(len(w))}
+        S = 0.0
+        reasons = []
+        for name, out, pcal in outputs:
+            contrib = weights[name] * out.direction * out.edge * (0.5 + 0.5 * pcal)
+            S += contrib
+            reasons += out.reasons
+        tau_buy, tau_sell = self.conformal.thresholds()
+        decision_dir = 0
+        if S > tau_buy:
+            decision_dir = +1
+        elif S < tau_sell:
+            decision_dir = -1
+        atr = float(row["atr"])
+        price = float(row["close"])
+        pos_pct = position_size(
+            S,
+            atr,
+            price,
+            target_vol=self.cfg.get("risk", {}).get("target_vol", 0.02),
+            maxRisk=self.cfg.get("risk", {}).get("max_risk_pct", 0.02),
+            kelly_clip=self.cfg.get("risk", {}).get("kelly_clip", 0.4),
+            p=max(0.01, min(0.99, 0.5 + 0.5 * abs(S))),
+            b=1.5,
+        )
+        kst = self.cfg.get("risk", {}).get("atr_stop", [1.0, 1.8])
+        ktp = self.cfg.get("risk", {}).get("atr_tp", [1.5, 2.5])
+        mult = 1 if decision_dir == +1 else -1
+        stop = price - mult * kst[0] * atr
+        tp = price + mult * ktp[0] * atr
+        return {
+            "symbol": symbol,
+            "timeframe": self.cfg.get("timeframe", "1h"),
+            "decision": ["SHORT", "HOLD", "LONG"][decision_dir + 1],
+            "direction": decision_dir,
+            "score": float(S),
+            "position_pct": float(pos_pct),
+            "stop": float(stop),
+            "take_profit": float(tp),
+            "horizon_days": 15,
+            "regime_probs": rp,
+            "weights": weights,
+            "reasons": reasons[:8],
+        }
+

--- a/backend/draks/routes.py
+++ b/backend/draks/routes.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+from flask import request, jsonify, current_app, g
+from datetime import datetime, timezone
+import pandas as pd
+import numpy as np
+
+try:
+    import ccxt  # opsiyonel: candles yoksa otomatik çeker
+except Exception:  # pragma: no cover
+    ccxt = None
+
+from backend.auth.jwt_utils import jwt_required_if_not_testing
+from backend.middleware.plan_limits import enforce_plan_limit
+from backend.utils.feature_flags import feature_flag_enabled
+from backend.utils.logger import create_log
+from backend.db.models import UsageLog
+from backend import db
+
+from . import draks_bp
+from .engine_min import DRAKSEngine
+
+# Basit konfig (gerekirse .yaml'dan okunabilir)
+CFG = {
+    "timeframe": "1h",
+    "cost_bps": 6,
+    "bandit": {"alpha": 0.5, "ridge": 1e-3},
+    "risk": {
+        "target_vol": 0.02,
+        "max_risk_pct": 0.02,
+        "kelly_clip": 0.4,
+        "atr_stop": [1.0, 1.8],
+        "atr_tp": [1.5, 2.5],
+    },
+    "thresholds": {"target_error_rate": 0.10, "buy": 0.02, "sell": -0.02},
+    "modules": [
+        {"name": "trend", "params": {}},
+        {"name": "momentum", "params": {}},
+        {"name": "meanrev", "params": {}},
+    ],
+}
+
+ENGINE = DRAKSEngine(CFG)
+
+
+def _df_from_candles(candles: list[dict]) -> pd.DataFrame:
+    """Gelen candle verisini DataFrame'e dönüştür."""
+    idx = []
+    rows = []
+    for c in candles:
+        ts = c.get("ts")
+        if isinstance(ts, (int, float)):
+            ts = datetime.fromtimestamp(
+                float(ts) / (1000 if float(ts) > 1e12 else 1), tz=timezone.utc
+            )
+        else:
+            ts = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        idx.append(ts)
+        rows.append(
+            {
+                "open": float(c["open"]),
+                "high": float(c["high"]),
+                "low": float(c["low"]),
+                "close": float(c["close"]),
+                "volume": float(c.get("volume", 0.0)),
+            }
+        )
+    df = pd.DataFrame(rows, index=pd.to_datetime(idx, utc=True))
+    return df.sort_index()
+
+
+def _fetch_ohlcv_ccxt(
+    symbol: str, timeframe: str = "1h", limit: int = 500
+) -> pd.DataFrame:
+    """CCXT ile borsadan OHLCV verisi çek."""
+    if ccxt is None:
+        raise RuntimeError("ccxt kurulu değil ve candles verilmedi")
+    ex = ccxt.binance({"enableRateLimit": True})
+    o = ex.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+    df = pd.DataFrame(o, columns=["ts", "open", "high", "low", "close", "volume"])
+    df["ts"] = pd.to_datetime(df["ts"], unit="ms", utc=True)
+    df = df.set_index("ts").sort_index()
+    return df
+
+
+@draks_bp.post("/decision/run")
+@jwt_required_if_not_testing()
+@enforce_plan_limit("draks_decision")
+def decision_run():
+    """Karar motorunu çalıştır."""
+    if not feature_flag_enabled("draks"):
+        return jsonify({"error": "Özellik şu anda devre dışı."}), 403
+
+    user = getattr(g, "user", None)
+    ip_address = request.remote_addr or "unknown"
+    user_agent = request.headers.get("User-Agent", "")
+
+    try:
+        p = request.get_json(force=True, silent=True) or {}
+        symbol = str(p.get("symbol", "BTC/USDT"))
+        timeframe = str(p.get("timeframe", CFG["timeframe"]))
+        limit = int(p.get("limit", 500))
+        candles = p.get("candles")
+
+        if candles:
+            df = _df_from_candles(candles)
+        else:
+            df = _fetch_ohlcv_ccxt(symbol, timeframe=timeframe, limit=limit)
+
+        if len(df) < 60:
+            return jsonify({"error": "yetersiz veri"}), 400
+
+        out = ENGINE.run(df, symbol.replace(" ", ""))
+        out["as_of"] = datetime.utcnow().isoformat() + "Z"
+
+        if user:
+            db.session.add(UsageLog(user_id=user.id, action="draks_decision"))
+            db.session.commit()
+            create_log(
+                user_id=str(user.id),
+                username=user.username,
+                ip_address=ip_address,
+                action="draks_decision",
+                target="/api/draks/decision/run",
+                description="DRAKS karar çalıştırıldı.",
+                status="success",
+                user_agent=user_agent,
+            )
+
+        return jsonify(out)
+    except Exception as e:  # pragma: no cover
+        current_app.logger.exception("draks decision error")
+        if user:
+            create_log(
+                user_id=str(user.id),
+                username=user.username,
+                ip_address=ip_address,
+                action="draks_decision",
+                target="/api/draks/decision/run",
+                description=str(e),
+                status="error",
+                user_agent=user_agent,
+            )
+        return jsonify({"error": str(e)}), 500
+
+
+@draks_bp.post("/copy/evaluate")
+@jwt_required_if_not_testing()
+@enforce_plan_limit("draks_copy")
+def copy_evaluate():
+    """Lider sinyalini değerlendir."""
+    if not feature_flag_enabled("draks"):
+        return jsonify({"error": "Özellik şu anda devre dışı."}), 403
+
+    user = getattr(g, "user", None)
+    ip_address = request.remote_addr or "unknown"
+    user_agent = request.headers.get("User-Agent", "")
+
+    try:
+        p = request.get_json(force=True, silent=True) or {}
+        side = str(p.get("side", "")).upper()
+        symbol = str(p.get("symbol", "BTC/USDT"))
+        timeframe = str(p.get("timeframe", CFG["timeframe"]))
+        limit = int(p.get("limit", 500))
+        candles = p.get("candles")
+
+        df = _df_from_candles(candles) if candles else _fetch_ohlcv_ccxt(
+            symbol, timeframe=timeframe, limit=limit
+        )
+        out = ENGINE.run(df, symbol.replace(" ", ""))
+
+        score = float(out.get("score", 0.0))
+        decision = str(out.get("decision", "HOLD")).upper()
+        greenlight = (decision == "LONG" and side == "BUY") or (
+            decision == "SHORT" and side == "SELL"
+        )
+        scale = max(0.0, min(1.0, abs(score) * 1.5)) if greenlight else 0.0
+        size = p.get("size")
+        scaled_size = (float(size) * scale) if (size is not None) else None
+
+        if user:
+            db.session.add(UsageLog(user_id=user.id, action="draks_copy"))
+            db.session.commit()
+            create_log(
+                user_id=str(user.id),
+                username=user.username,
+                ip_address=ip_address,
+                action="draks_copy",
+                target="/api/draks/copy/evaluate",
+                description="DRAKS kopya sinyali değerlendirildi.",
+                status="success",
+                user_agent=user_agent,
+            )
+
+        return jsonify({"greenlight": greenlight, "scaled_size": scaled_size, "draks": out})
+    except Exception as e:  # pragma: no cover
+        current_app.logger.exception("draks eval error")
+        if user:
+            create_log(
+                user_id=str(user.id),
+                username=user.username,
+                ip_address=ip_address,
+                action="draks_copy",
+                target="/api/draks/copy/evaluate",
+                description=str(e),
+                status="error",
+                user_agent=user_agent,
+            )
+        return jsonify({"error": str(e)}), 500

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -30,3 +30,13 @@ flask_socketio
 loguru
 requests
 psutil
+
+# --- DRAKS için ek bağımlılıklar ---
+numpy>=1.26.0
+pandas>=2.2.0
+scikit-learn>=1.4.0
+ccxt>=4.0.0
+python-dateutil>=2.9.0
+APScheduler>=3.10.0
+feedparser>=6.0.10
+yfinance>=0.2.36

--- a/backend/tests/test_draks_routes.py
+++ b/backend/tests/test_draks_routes.py
@@ -1,0 +1,80 @@
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+from backend import create_app, db
+from backend.db.models import User, SubscriptionPlan, UserRole
+from backend.models.plan import Plan
+from backend.utils.feature_flags import set_feature_flag
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    app = create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def user(app):
+    with app.app_context():
+        plan = Plan(name="basic", price=0.0, features=json.dumps({"draks_decision": 1}))
+        db.session.add(plan)
+        db.session.commit()
+        u = User(
+            username="draks_user",
+            subscription_level=SubscriptionPlan.BASIC,
+            role=UserRole.USER,
+            plan_id=plan.id,
+        )
+        u.set_password("pass")
+        u.generate_api_key()
+        db.session.add(u)
+        db.session.commit()
+        return u
+
+
+def _candles(n=60):
+    now = int(datetime.utcnow().timestamp())
+    candles = []
+    for i in range(n):
+        ts = now - (n - i) * 60
+        candles.append({"ts": ts, "open": 1, "high": 1, "low": 1, "close": 1, "volume": 1})
+    return candles
+
+
+def test_decision_run_feature_flag(app, user):
+    client = app.test_client()
+    with app.app_context():
+        set_feature_flag("draks", False)
+        resp = client.post(
+            "/api/draks/decision/run",
+            headers={"X-API-KEY": user.api_key},
+            json={"symbol": "BTC/USDT", "candles": _candles()},
+        )
+        assert resp.status_code == 403
+
+
+def test_decision_run_limit_enforced(app, user):
+    client = app.test_client()
+    with app.app_context():
+        set_feature_flag("draks", True)
+        payload = {"symbol": "BTC/USDT", "candles": _candles()}
+        resp1 = client.post(
+            "/api/draks/decision/run",
+            headers={"X-API-KEY": user.api_key},
+            json=payload,
+        )
+        assert resp1.status_code == 200
+        resp2 = client.post(
+            "/api/draks/decision/run",
+            headers={"X-API-KEY": user.api_key},
+            json=payload,
+        )
+        assert resp2.status_code == 429

--- a/backend/utils/feature_flags.py
+++ b/backend/utils/feature_flags.py
@@ -31,6 +31,7 @@ _default_flags: Dict[str, bool] = {
     "next_generation_model": False,
     "advanced_forecast": False,
     "health_check": True,
+    "draks": False,
 }
 
 # In-memory metadata store for feature flags

--- a/migrations/20250814_add_draks_tables.sql
+++ b/migrations/20250814_add_draks_tables.sql
@@ -1,0 +1,25 @@
+-- DRAKS sonuçları için şeffaf takip tabloları (opsiyonel)
+CREATE TABLE IF NOT EXISTS draks_signal_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  symbol TEXT NOT NULL,
+  timeframe TEXT NOT NULL DEFAULT '1h',
+  regime_probs TEXT NOT NULL,
+  weights TEXT NOT NULL,
+  score REAL NOT NULL,
+  decision TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_draks_signal_runs_symbol ON draks_signal_runs(symbol, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS draks_decisions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  symbol TEXT NOT NULL,
+  decision TEXT NOT NULL,          -- LONG/SHORT/HOLD
+  position_pct REAL,
+  stop REAL,
+  take_profit REAL,
+  reasons TEXT,                    -- JSON string
+  raw_response TEXT,               -- JSON string
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_draks_decisions_symbol ON draks_decisions(symbol, created_at DESC);

--- a/scripts/draks_ingest.py
+++ b/scripts/draks_ingest.py
@@ -1,0 +1,90 @@
+"""
+Basit otomatik veri çekici:
+- CCXT ile kripto OHLCV (Binance varsayılan)
+- yfinance ile BIST/hisse günlük
+Sonuçlar ohlcv tablosuna yazar (yoksa oluşturur).
+"""
+from __future__ import annotations
+from datetime import datetime, timezone
+import time
+import pandas as pd
+from sqlalchemy import text, create_engine
+import os
+
+DB_URL = os.getenv("DATABASE_URL", "sqlite:///ytd.db")
+ENGINE = create_engine(DB_URL, future=True)
+
+DDL = """
+CREATE TABLE IF NOT EXISTS ohlcv (
+  symbol TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  ts TIMESTAMP NOT NULL,
+  open REAL, high REAL, low REAL, close REAL, volume REAL,
+  source TEXT DEFAULT 'unknown',
+  PRIMARY KEY (symbol,timeframe,ts)
+);
+"""
+with ENGINE.begin() as con:
+    con.execute(text(DDL))
+
+
+def write_ohlcv(df: pd.DataFrame, *, symbol: str, timeframe: str, source: str):
+    if df.empty:
+        return
+    df = df.copy()
+    df["symbol"] = symbol
+    df["timeframe"] = timeframe
+    df["source"] = source
+    with ENGINE.begin() as con:
+        tmp = "ohlcv_tmp"
+        df.to_sql(tmp, con, if_exists="replace", index=False)
+        con.execute(
+            text(
+                f"""
+            INSERT OR IGNORE INTO ohlcv (symbol,timeframe,ts,open,high,low,close,volume,source)
+            SELECT '{symbol}','{timeframe}', ts, open, high, low, close, volume, '{source}' FROM {tmp};
+            DROP TABLE {tmp};
+        """
+            )
+        )
+
+
+def collect_ccxt(symbols=("BTC/USDT", "ETH/USDT"), timeframes=("1h", "1d"), limit=500, ex_id="binance"):
+    import ccxt
+
+    ex = getattr(ccxt, ex_id)({"enableRateLimit": True})
+    for sym in symbols:
+        for tf in timeframes:
+            o = ex.fetch_ohlcv(sym, timeframe=tf, limit=limit)
+            df = pd.DataFrame(o, columns=["ts", "open", "high", "low", "close", "volume"])
+            df["ts"] = pd.to_datetime(df["ts"], unit="ms", utc=True)
+            write_ohlcv(df, symbol=sym.replace(" ", ""), timeframe=tf, source=ex_id)
+            time.sleep(0.25)
+
+
+def collect_yf(symbols=("XU100.IS", "GARAN.IS"), interval="1d", period="720d"):
+    import yfinance as yf
+
+    for sym in symbols:
+        df = yf.download(sym, interval=interval, period=period, progress=False)
+        if df.empty:
+            continue
+        out = df.rename(
+            columns={
+                "Open": "open",
+                "High": "high",
+                "Low": "low",
+                "Close": "close",
+                "Volume": "volume",
+            }
+        )
+        out.reset_index(inplace=True)
+        out.rename(columns={out.columns[0]: "ts"}, inplace=True)
+        out["ts"] = pd.to_datetime(out["ts"], utc=True)
+        write_ohlcv(out[["ts", "open", "high", "low", "close", "volume"]], symbol=sym, timeframe=interval, source="yfinance")
+
+
+if __name__ == "__main__":
+    collect_ccxt()
+    collect_yf()
+    print("draks_ingest tamam")


### PR DESCRIPTION
## Summary
- add DRAKS decision engine blueprint with authenticated, rate-limited routes
- include supporting engine, scripts, migrations and feature flag
- test DRAKS decision run endpoint and feature flag/limit enforcement

## Testing
- `pytest backend/tests/test_draks_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e1ab593f8832f9f5c93f62935e538