### PR TITLE
Enhance DRAKS copy evaluate validation

### DIFF
--- a/backend/tests/test_draks_copy_evaluate.py
+++ b/backend/tests/test_draks_copy_evaluate.py
@@ -1,0 +1,143 @@
+import json
+from datetime import datetime
+import pytest
+
+from backend import create_app, db
+from backend.db.models import User, SubscriptionPlan, UserRole
+from backend.models.plan import Plan
+from backend.utils.feature_flags import create_feature_flag
+
+
+def _candles(n=80):
+    now = int(datetime.utcnow().timestamp())
+    out = []
+    px = 100.0
+    for i in range(n):
+        ts = now - (n - i) * 60
+        px *= 1.001  # küçük drift
+        out.append({"ts": ts, "open": px-2, "high": px+2, "low": px-3, "close": px, "volume": 1000+i})
+    return out
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    # JWT doğrulamayı bypass et
+    monkeypatch.setattr(
+        "flask_jwt_extended.view_decorators.verify_jwt_in_request",
+        lambda *a, **k: None,
+    )
+    app = create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def user(app):
+    with app.app_context():
+        plan = Plan(
+            name="basic",
+            price=0.0,
+            features=json.dumps({"draks_copy": 2, "predict_daily": 10}),
+        )
+        db.session.add(plan)
+        db.session.commit()
+        u = User(
+            username="copy_user",
+            subscription_level=SubscriptionPlan.BASIC,
+            role=UserRole.USER,
+            plan_id=plan.id,
+        )
+        u.set_password("pass")
+        u.generate_api_key()
+        db.session.add(u)
+        db.session.commit()
+        return u
+
+
+@pytest.fixture
+def auth_headers(app, user):
+    with app.app_context():
+        token = user.generate_access_token()
+    return {"Authorization": f"Bearer {token}", "X-API-KEY": user.api_key}
+
+
+def test_copy_eval_flag_off(app, user, auth_headers):
+    client = app.test_client()
+    with app.app_context():
+        create_feature_flag("draks", False)
+        resp = client.post("/api/draks/copy/evaluate",
+                           headers=auth_headers,
+                           json={"symbol": "BTC/USDT", "side": "BUY", "candles": _candles()})
+        assert resp.status_code == 403
+
+
+def test_copy_eval_ok_and_limit(app, user, auth_headers, monkeypatch):
+    client = app.test_client()
+    with app.app_context():
+        create_feature_flag("draks", True)
+        payload = {"symbol": "BTC/USDT", "side": "BUY", "size": 1000, "candles": _candles()}
+        r1 = client.post("/api/draks/copy/evaluate", headers=auth_headers, json=payload)
+        assert r1.status_code == 200
+        body = r1.get_json()
+        assert "greenlight" in body and "scale_factor" in body and "draks" in body
+        # 2. istek: plan 'draks_copy': 2 → bu da geçmeli
+        r2 = client.post("/api/draks/copy/evaluate", headers=auth_headers, json=payload)
+        assert r2.status_code == 200
+        # 3. istek: limit aşımı
+        r3 = client.post("/api/draks/copy/evaluate", headers=auth_headers, json=payload)
+        assert r3.status_code == 429
+
+
+@pytest.mark.parametrize("side", ["", "BUYSELL", "hold", None])
+def test_copy_eval_bad_side(app, user, auth_headers, side):
+    client = app.test_client()
+    with app.app_context():
+        create_feature_flag("draks", True)
+        payload = {"symbol": "BTC/USDT", "side": side, "candles": _candles()}
+        r = client.post("/api/draks/copy/evaluate", headers=auth_headers, json=payload)
+        assert r.status_code == 400
+        assert "side" in r.get_json().get("error", "").lower()
+
+
+def test_copy_eval_bad_size(app, user, auth_headers):
+    client = app.test_client()
+    with app.app_context():
+        create_feature_flag("draks", True)
+        # str size
+        r1 = client.post("/api/draks/copy/evaluate", headers=auth_headers,
+                         json={"symbol": "BTC/USDT", "side": "BUY", "size": "x", "candles": _candles()})
+        assert r1.status_code == 400
+        # negatif size
+        r2 = client.post("/api/draks/copy/evaluate", headers=auth_headers,
+                         json={"symbol": "BTC/USDT", "side": "BUY", "size": -10, "candles": _candles()})
+        assert r2.status_code == 400
+
+
+def test_copy_eval_no_candles_and_no_ccxt(app, user, auth_headers, monkeypatch):
+    client = app.test_client()
+    with app.app_context():
+        create_feature_flag("draks", True)
+        # ccxt kullanılamasın diye modül referansını None yap
+        monkeypatch.setattr("backend.draks.routes.ccxt", None, raising=False)
+        resp = client.post("/api/draks/copy/evaluate",
+                           headers=auth_headers,
+                           json={"symbol": "BTC/USDT", "side": "BUY"})
+        assert resp.status_code == 400
+        assert "candles" in resp.get_json().get("error","")
+
+
+def test_copy_eval_insufficient_data(app, user, auth_headers):
+    client = app.test_client()
+    with app.app_context():
+        create_feature_flag("draks", True)
+        few = _candles(10)  # yetersiz
+        resp = client.post("/api/draks/copy/evaluate",
+                           headers=auth_headers,
+                           json={"symbol": "BTC/USDT", "side": "BUY", "candles": few})
+        assert resp.status_code == 400
+        assert resp.get_json().get("error") == "yetersiz veri"

--- a/docs/api.md
+++ b/docs/api.md
@@ -131,9 +131,10 @@ Kopya (copy-trading) senaryosunda lider sinyali DRAKS ile doğrular; yeşil ış
 {
   "symbol": "BTC/USDT",
   "side": "BUY",                  // veya SELL
-  "size": 1000,                   // opsiyonel nominal büyüklük
+  "size": 1000,                   // opsiyonel nominal büyüklük (>= 0, sayısal)
   "timeframe": "1h",
-  "candles": [ /* opsiyonel */ ]
+  "limit": 500,                   // opsiyonel, candles yoksa ccxt ile çekilecek mum sayısı
+  "candles": [ /* opsiyonel, sağlanırsa ccxt'e ihtiyaç yok */ ]
 }
 ```
 
@@ -141,10 +142,25 @@ Kopya (copy-trading) senaryosunda lider sinyali DRAKS ile doğrular; yeşil ış
 ```json
 {
   "greenlight": true,
-  "scaled_size": 640.5,           // size * ölçek faktörü (0..1), yoksa null
+  "scale_factor": 0.64,           // 0..1 arası ölçek katsayısı
+  "scaled_size": 640.5,           // size * scale_factor, size yoksa null
   "draks": { /* decision.run cevabı */ }
 }
 ```
 
 ### Hatalar
-403 (flag), 429 (limit), 500 (sunucu hatası).
+-403 (flag), 429 (limit), 500 (sunucu hatası). +- 400:
+
+Geçersiz side. BUY veya SELL olmalı.
+
+
+size sayısal olmalı / size negatif olamaz
+
+
+limit sayısal olmalı
+
+
+candles sağlanmalı veya ccxt kurulmalı
+
+
+yetersiz veri

--- a/scripts/draks_quicktest.sh
+++ b/scripts/draks_quicktest.sh
@@ -36,13 +36,31 @@ curl -sS -H "Content-Type: application/json" ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
 
 echo
 echo "==> copy/evaluate"
+# Aynı candles'ı kullanarak ccxt'e ihtiyaç bırakmayalım
 COPY_PAYLOAD="$(cat <<JSON
 {
-  "symbol": "BTC/USDT",
-  "side": "BUY",
-  "size": 1000,
-  "timeframe": "1h",
-  "candles": []
+
+"symbol": "BTC/USDT",
+
+"side": "BUY",
+
+"size": 1000,
+
+"timeframe": "1h",
+
+"candles": [
+
+{ "ts": $((NOW-3600*5)), "open": 100, "high": 110, "low": 95, "close": 105, "volume": 1200 },
+
+{ "ts": $((NOW-3600*4)), "open": 105, "high": 111, "low": 100, "close": 108, "volume": 1300 },
+
+{ "ts": $((NOW-3600*3)), "open": 108, "high": 115, "low": 104, "close": 113, "volume": 1400 },
+
+{ "ts": $((NOW-3600*2)), "open": 113, "high": 116, "low": 110, "close": 114, "volume": 1500 },
+
+{ "ts": $((NOW-3600*1)), "open": 114, "high": 118, "low": 112, "close": 117, "volume": 1600 }
+
+]
 }
 JSON
 )"


### PR DESCRIPTION
## Summary
- enforce detailed input validation and ccxt fallback in `/api/draks/copy/evaluate`
- document new parameters and scale factor in API docs and quicktest script
- add comprehensive tests for DRAKS copy evaluation endpoint

## Testing
- `PYTHONPATH=. pytest backend/tests/test_draks_copy_evaluate.py`

------
https://chatgpt.com/codex/tasks/task_e_689e3ee947d0832f8bb880549bd9094c