### PR TITLE
Expose DRAKS health info and admin detail endpoints

### DIFF
--- a/backend/draks/routes.py
+++ b/backend/draks/routes.py
@@ -85,9 +85,20 @@ def draks_health():
     """
     try:
         enabled = feature_flag_enabled("draks")
+        use_advanced = (
+            feature_flag_enabled("draks_advanced")
+            or os.getenv("DRAKS_ADVANCED", "0").lower() in {"1", "true", "yes"}
+        )
+        live_mode = os.getenv("DRAKS_LIVE_MODE", "0").lower() in {"1", "true", "yes"}
         # Minimal kontrol: engine objesi çalışıyor mu?
         ok = ENGINE is not None
-        return jsonify({"status": "ok" if ok else "degraded", "enabled": enabled}), 200
+        return jsonify({
+            "status": "ok" if ok else "degraded",
+            "enabled": enabled,
+            "advanced": bool(use_advanced),
+            "live_mode": bool(live_mode),
+            "timeframe": CFG.get("timeframe", "1h")
+        }), 200
     except Exception as e:  # pragma: no cover
         current_app.logger.exception("draks health error")
         return jsonify({"status": "error", "error": str(e)}), 500

--- a/frontend/react/pages/AdminDraks.tsx
+++ b/frontend/react/pages/AdminDraks.tsx
@@ -24,6 +24,9 @@ export default function AdminDraks() {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
   const [symbol, setSymbol] = useState("");
+  const [health, setHealth] = useState<{enabled:boolean; advanced:boolean; live_mode:boolean; timeframe?:string} | null>(null);
+  const [detail, setDetail] = useState<any | null>(null);
+  const [showDetail, setShowDetail] = useState(false);
 
   const headers = useMemo(() => {
     const h: Record<string, string> = {
@@ -60,14 +63,46 @@ export default function AdminDraks() {
     }
   }
 
+  async function loadHealth() {
+    try {
+      const r = await fetch(`/api/draks/health`, { headers, credentials: "include" });
+      const j = await r.json();
+      if (r.ok) {
+        setHealth({ enabled: !!j.enabled, advanced: !!j.advanced, live_mode: !!j.live_mode, timeframe: j.timeframe });
+      }
+    } catch (e) { /* noop */ }
+  }
+
+  async function openDetail(row: Row) {
+    try {
+      const endpoint = tab === "decisions" ? `/api/admin/draks/decisions/${row.id}` : `/api/admin/draks/signals/${row.id}`;
+      const r = await fetch(endpoint, { headers, credentials: "include" });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j?.error || `HTTP ${r.status}`);
+      setDetail(j);
+      setShowDetail(true);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   useEffect(() => {
-    load();
+    load(); loadHealth();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab, page]);
 
   return (
     <div className="space-y-3 p-2">
       <h1 className="text-xl font-semibold">DRAKS Monitor</h1>
+      {health && (
+        <div className="text-xs rounded border p-2 flex gap-4 items-center bg-gray-50">
+          <div><b>Enabled:</b> {String(health.enabled)}</div>
+          <div><b>Advanced:</b> {String(health.advanced)}</div>
+          <div><b>Live mode:</b> {String(health.live_mode)}</div>
+          {health.timeframe && <div><b>TF:</b> {health.timeframe}</div>}
+          <button className="ml-auto border rounded px-2 py-1" onClick={loadHealth}>Yenile</button>
+        </div>
+      )}
       <div className="flex gap-2 items-center">
         <button
           className={`border rounded px-2 py-1 text-sm ${tab === "decisions" ? "bg-gray-100" : ""}`}
@@ -123,6 +158,7 @@ export default function AdminDraks() {
                   <th className="text-left p-2">Pos%</th>
                 )}
                 <th className="text-left p-2">Created</th>
+                <th className="text-left p-2">Detay</th>
               </tr>
             </thead>
             <tbody>
@@ -147,11 +183,14 @@ export default function AdminDraks() {
                     </td>
                   )}
                   <td className="p-2">{r.created_at}</td>
+                  <td className="p-2">
+                    <button className="border rounded px-2 py-1 text-xs" onClick={() => openDetail(r)}>Detay</button>
+                  </td>
                 </tr>
               ))}
               {!items.length && (
                 <tr>
-                  <td className="p-2" colSpan={5}>
+                  <td className="p-2" colSpan={6}>
                     Kayıt bulunamadı.
                   </td>
                 </tr>
@@ -180,6 +219,48 @@ export default function AdminDraks() {
           Toplam: {total}
         </div>
       </div>
+
+      {/* Detay Modal */}
+      {showDetail && detail && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded shadow-lg w-[90vw] max-w-3xl max-h-[80vh] overflow-auto">
+            <div className="p-3 border-b flex items-center">
+              <div className="font-semibold text-sm">Detay</div>
+              <button className="ml-auto border rounded px-2 py-1 text-xs" onClick={() => setShowDetail(false)}>Kapat</button>
+            </div>
+            <div className="p-3 space-y-2 text-sm">
+              {"decision" in detail && (
+                <div className="text-xs">
+                  <b>Decision:</b> {detail.decision} &nbsp;|&nbsp; <b>Symbol:</b> {detail.symbol}
+                </div>
+              )}
+              {"score" in detail && (
+                <div className="text-xs">
+                  <b>Score:</b> {typeof detail.score === "number" ? detail.score.toFixed(4) : String(detail.score)}
+                  &nbsp;|&nbsp;<b>Timeframe:</b> {detail.timeframe}
+                </div>
+              )}
+              {"position_pct" in detail && typeof detail.position_pct === "number" && (
+                <div className="text-xs">
+                  <b>Pos%:</b> {(detail.position_pct * 100).toFixed(2)}% &nbsp;|&nbsp; <b>Stop:</b> {detail.stop} &nbsp;|&nbsp; <b>TP:</b> {detail.take_profit}
+                </div>
+              )}
+              {Array.isArray(detail.reasons) && detail.reasons.length > 0 && (
+                <div>
+                  <div className="font-medium">Reasons</div>
+                  <ul className="list-disc ml-4">
+                    {detail.reasons.map((r: string, i: number) => <li key={i}>{r}</li>)}
+                  </ul>
+                </div>
+              )}
+              <div>
+                <div className="font-medium">Raw</div>
+                <pre className="text-xs bg-gray-50 border rounded p-2 overflow-auto">{JSON.stringify(detail, null, 2)}</pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/tests/test_admin_draks_monitor.py
+++ b/tests/test_admin_draks_monitor.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from backend import create_app, db
 from backend.db.models import DraksDecision, DraksSignalRun
 from backend.utils.feature_flags import set_feature_flag
+import json
 
 
 @pytest.fixture
@@ -43,6 +44,11 @@ def test_list_decisions(admin_client):
     data = resp.get_json()
     assert data["meta"]["total"] == 1
     assert data["items"][0]["symbol"] == "BTC/USDT"
+    # detail
+    row_id = data["items"][0]["id"]
+    d = admin_client.get(f"/api/admin/draks/decisions/{row_id}")
+    assert d.status_code == 200
+    assert d.get_json()["symbol"] == "BTC/USDT"
 
 
 def test_list_signals(admin_client):
@@ -66,4 +72,11 @@ def test_list_signals(admin_client):
     data = resp.get_json()
     assert data["meta"]["total"] == 1
     assert data["items"][0]["symbol"] == "BTC/USDT"
+    # detail
+    row_id = data["items"][0]["id"]
+    d = admin_client.get(f"/api/admin/draks/signals/{row_id}")
+    assert d.status_code == 200
+    jd = d.get_json()
+    assert jd["symbol"] == "BTC/USDT"
+    assert "regime_probs" in jd and "weights" in jd
 


### PR DESCRIPTION
## Summary
- extend `/api/draks/health` with advanced, live mode and timeframe indicators
- add admin endpoints to fetch DRAKS decision and signal details
- enhance AdminDraks page with health banner and detail modal
- test detail endpoints for decisions and signals

## Testing
- `pytest tests/test_admin_draks_monitor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8fabf1e0832fa40be82d1dc4623a