### PR TITLE
feat: allow running tests from admin panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ ENABLE_SCHEDULER=false                    # True ise background scheduler çalı
 USE_REDIS_FEATURE_FLAGS=false             # Özellik bayrakları için Redis kullan
 REDIS_URL=redis://localhost:6379/0        # Redis URL (flag yönetimi için)
 
+# ---------- TEST ÇALIŞTIRMA (Admin) ----------
+# Admin panelinden test tetiklemeyi aç/kapat.
+# PROD'da default kapalı tutmanız önerilir.
+ALLOW_ADMIN_TEST_RUN=false
+
 # ---------- METRICS / OBSERVABILITY ----------
 # /metrics endpoint'i için opsiyonel temel kimlik doğrulama
 METRICS_BASIC_AUTH_USER=

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -285,6 +285,7 @@ def create_app() -> Flask:
     from backend.api.admin.logs import admin_logs_bp
     from backend.api.admin.feature_flags import feature_flags_bp
     from backend.api.admin.draks_monitor import admin_draks_bp
+    from backend.api.admin.tests import admin_tests_bp
     from backend.api.limits import bp as limits_bp
     from backend.api.ta_routes import bp as ta_bp
     from backend.api.public.technical import technical_bp
@@ -330,6 +331,7 @@ def create_app() -> Flask:
     app.register_blueprint(technical_bp)
     app.register_blueprint(feature_flags_bp, url_prefix="/api/admin")
     app.register_blueprint(admin_draks_bp)
+    app.register_blueprint(admin_tests_bp)
     app.register_blueprint(decision_bp)
     app.register_blueprint(subscriptions_bp)
     app.register_blueprint(limits_bp)

--- a/backend/api/admin/tests.py
+++ b/backend/api/admin/tests.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+import os, re, shlex, subprocess
+from flask import Blueprint, jsonify, request, g
+from backend.auth.jwt_utils import jwt_required_if_not_testing
+from backend.auth.middlewares import admin_required
+from backend.utils.logger import create_log
+from backend.observability.metrics import inc_error
+from backend import limiter
+
+admin_tests_bp = Blueprint("admin_tests", __name__, url_prefix="/api/admin/tests")
+
+# Ortam değişkeni ile kapatılabilir
+_ALLOW = os.getenv("ALLOW_ADMIN_TEST_RUN", "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _suite_to_pytest_args(suite: str) -> list[str]:
+    """Verilen suite adını pytest argümanlarına çevir."""
+    if suite == "smoke":
+        return ["-q", "-k", "smoke", "--maxfail=1", "--disable-warnings"]
+    if suite == "unit":
+        return ["-q", "-k", "not e2e and not slow", "--disable-warnings"]
+    return ["-q", "-k", "not e2e", "--disable-warnings"]
+
+
+def _parse_summary(text: str) -> dict:
+    """Pytest özet satırını ayrıştır."""
+    m = re.search(r"=+ (.+?) =+\s*$", text, flags=re.M | re.S)
+    summary = m.group(1).strip() if m else ""
+    counts = {"passed": 0, "failed": 0, "errors": 0, "skipped": 0, "xfailed": 0, "xpassed": 0}
+    for key in counts.keys():
+        mm = re.search(rf"(\d+)\s+{key}", summary)
+        if mm:
+            counts[key] = int(mm.group(1))
+    return {"raw": summary, **counts}
+
+
+@admin_tests_bp.post("/run")
+@jwt_required_if_not_testing()
+@admin_required()
+@limiter.limit("6/hour")
+def run_tests():
+    """Sunucu üzerinde testleri çalıştır."""
+    if not _ALLOW:
+        inc_error("tests_forbidden")
+        return jsonify({"error": "Test çalıştırma devre dışı. ALLOW_ADMIN_TEST_RUN=true yapın."}), 403
+
+    body = request.json or {}
+    suite = body.get("suite", "unit")
+    extra = body.get("extra", "").strip()
+    args = ["pytest", *_suite_to_pytest_args(suite)]
+
+    # Ek argümanları basit regex ile filtrele
+    if extra:
+        if not re.fullmatch(r"[A-Za-z0-9_\-\s/\.=]*", extra):
+            return jsonify({"error": "Geçersiz extra argümanlar"}), 400
+        args.extend(shlex.split(extra))
+
+    try:
+        proc = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        )
+        stdout = proc.stdout or ""
+        stderr = proc.stderr or ""
+
+        def _clip(s: str, lim: int = 20000) -> str:
+            return s if len(s) <= lim else s[:lim] + "\n... (truncated) ...\n"
+
+        result = {
+            "exit_code": proc.returncode,
+            "suite": suite,
+            "cmd": " ".join(args),
+            "summary": _parse_summary(stdout + "\n" + stderr),
+            "stdout": _clip(stdout),
+            "stderr": _clip(stderr),
+        }
+
+        user = g.get("user")
+        if user:
+            create_log(
+                user_id=str(user.id),
+                username=user.username,
+                ip_address=request.remote_addr or "unknown",
+                action="admin_tests_run",
+                target="/api/admin/tests/run",
+                description=f"suite={suite} exit={proc.returncode}",
+                status="success" if proc.returncode == 0 else "error",
+                user_agent=request.headers.get("User-Agent", ""),
+            )
+
+        status = 200 if proc.returncode == 0 else 202
+        return jsonify(result), status
+
+    except subprocess.TimeoutExpired:
+        inc_error("tests_timeout")
+        return jsonify({"error": "Test çalıştırma zaman aşımına uğradı (timeout)."}), 504
+    except Exception as e:  # pragma: no cover
+        inc_error("tests_exception")
+        return jsonify({"error": str(e)}), 500

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -36,3 +36,12 @@ scrape_configs:
 - Panel: Latency p95/p99 (`histogram_quantile` ile)
 - Panel: Success ratio = 200 / (200+4xx+5xx)
 - Panel: Errors by type (`draks_errors_total{type}` rate())
+
+## Admin Test Çalıştırma
+- Endpoint: `POST /api/admin/tests/run` (sadece admin, rate-limit 6/saat)
+- Env toggle: `ALLOW_ADMIN_TEST_RUN=true` (default: false)
+- Request body:
+```json
+{ "suite": "unit|smoke|all", "extra": "-k mypattern" }
+```
+- Response: exit_code, özet, stdout/stderr (kısaltılmış) içerir.

--- a/frontend/react/admin/AdminRoutes.tsx
+++ b/frontend/react/admin/AdminRoutes.tsx
@@ -11,6 +11,7 @@ import AdminMonitoring from '../pages/AdminMonitoring';
 import AdminLogs from '../pages/AdminLogs';
 import AdminFeatureFlags from '../pages/AdminFeatureFlags';
 import AdminDraks from '../pages/AdminDraks';
+import AdminTests from '../pages/AdminTests';
 import UserDetail from './UserDetail';
 
 const AdminRoutes = () => {
@@ -26,6 +27,7 @@ const AdminRoutes = () => {
       <Route path="content" element={<AdminContent />} />
       <Route path="monitoring" element={<AdminMonitoring />} />
       <Route path="draks" element={<AdminDraks />} />
+      <Route path="tests" element={<AdminTests />} />
       <Route path="feature-flags" element={<AdminFeatureFlags />} />
       <Route path="logs" element={<AdminLogs />} />
     </Routes>

--- a/frontend/react/pages/AdminTests.tsx
+++ b/frontend/react/pages/AdminTests.tsx
@@ -1,0 +1,107 @@
+import React, { useMemo, useState } from "react";
+
+type Result = {
+  exit_code: number;
+  suite: string;
+  cmd: string;
+  summary: { raw: string; passed: number; failed: number; errors: number; skipped: number; xfailed: number; xpassed: number };
+  stdout: string;
+  stderr: string;
+};
+
+export default function AdminTests() {
+  const [suite, setSuite] = useState<"unit" | "smoke" | "all">("unit");
+  const [extra, setExtra] = useState("");
+  const [running, setRunning] = useState(false);
+  const [res, setRes] = useState<Result | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const headers = useMemo(() => {
+    const h: Record<string, string> = { "Content-Type": "application/json" };
+    const token = localStorage.getItem("access_token");
+    const apiKey = localStorage.getItem("api_key");
+    if (token) h["Authorization"] = `Bearer ${token}`;
+    if (apiKey) h["X-API-KEY"] = `${apiKey}`;
+    return h;
+  }, []);
+
+  async function run() {
+    setRunning(true);
+    setError(null);
+    setRes(null);
+    try {
+      const r = await fetch("/api/admin/tests/run", {
+        method: "POST",
+        headers,
+        credentials: "include",
+        body: JSON.stringify({ suite, extra }),
+      });
+      const j = await r.json();
+      if (!r.ok && ![202].includes(r.status)) throw new Error(j?.error || `HTTP ${r.status}`);
+      setRes(j);
+    } catch (e: any) {
+      setError(e.message || String(e));
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <div className="p-3 space-y-3">
+      <h1 className="text-xl font-semibold">Admin: Test Çalıştır</h1>
+      <div className="border rounded p-3 space-y-2 bg-gray-50">
+        <div className="flex gap-2 items-center">
+          <label className="text-sm">Suite</label>
+          <select className="border rounded px-2 py-1 text-sm" value={suite} onChange={(e) => setSuite(e.target.value as any)}>
+            <option value="unit">Unit (default)</option>
+            <option value="smoke">Smoke</option>
+            <option value="all">All (not e2e)</option>
+          </select>
+          <input
+            className="border rounded px-2 py-1 text-sm flex-1"
+            placeholder="Ek pytest argümanları (opsiyonel)"
+            value={extra}
+            onChange={(e) => setExtra(e.target.value)}
+          />
+          <button disabled={running} onClick={run} className="border rounded px-3 py-1 text-sm bg-white">
+            {running ? "Çalışıyor…" : "Testleri Çalıştır"}
+          </button>
+        </div>
+        <div className="text-xs text-gray-600">
+          Not: Bu özellik sadece <code>ALLOW_ADMIN_TEST_RUN=true</code> iken çalışır. Üretimde kapalı tutmanız önerilir.
+        </div>
+      </div>
+      {error && <div className="border rounded p-2 text-sm text-red-600 bg-red-50">Hata: {error}</div>}
+      {res && (
+        <div className="space-y-3">
+          <div className="border rounded p-3">
+            <div className="text-sm">
+              <b>Komut:</b> <code>{res.cmd}</code>
+            </div>
+            <div className="text-sm">
+              <b>Çıkış Kodu:</b> {res.exit_code}
+            </div>
+            <div className="text-sm">
+              <b>Özet:</b> {res.summary?.raw}</div>
+            <div className="grid grid-cols-3 gap-3 mt-2 text-sm">
+              <div className="border rounded p-2 bg-gray-50">passed: {res.summary?.passed}</div>
+              <div className="border rounded p-2 bg-gray-50">failed: {res.summary?.failed}</div>
+              <div className="border rounded p-2 bg-gray-50">errors: {res.summary?.errors}</div>
+            </div>
+          </div>
+          <div className="grid md:grid-cols-2 gap-3">
+            <div className="border rounded overflow-hidden">
+              <div className="text-sm font-medium bg-gray-100 p-2">STDOUT</div>
+              <pre className="p-2 text-xs overflow-auto max-h-[50vh] whitespace-pre-wrap">{res.stdout || "(empty)"}</pre>
+            </div>
+            <div className="border rounded overflow-hidden">
+              <div className="text-sm font-medium bg-gray-100 p-2">STDERR</div>
+              <pre className="p-2 text-xs overflow-auto max-h-[50vh] whitespace-pre-wrap">{res.stderr || "(empty)"}</pre>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/tests/test_admin_tests_api.py
+++ b/tests/test_admin_tests_api.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from backend import create_app
+import importlib
+
+
+def test_run_tests(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setenv("ALLOW_ADMIN_TEST_RUN", "true")
+    # admin_required bypass
+    monkeypatch.setattr("backend.auth.middlewares.admin_required", lambda: (lambda f: f))
+
+    # Ortam değişkeni değiştikten sonra modülü yeniden yükle
+    import backend.api.admin.tests as admin_tests_module
+    importlib.reload(admin_tests_module)
+
+    # subprocess.run'ı sahte sonuç dönecek şekilde patchle
+    def fake_run(args, capture_output, text, timeout, env):
+        return SimpleNamespace(returncode=0, stdout="=== 1 passed in 0.01s ===", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    app = create_app()
+    client = app.test_client()
+
+    resp = client.post("/api/admin/tests/run", json={"suite": "unit"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["summary"]["passed"] == 1
+    assert data["exit_code"] == 0


### PR DESCRIPTION
## Summary
- allow admins to trigger backend test suites with `/api/admin/tests/run`
- add React page for manual test execution
- document `ALLOW_ADMIN_TEST_RUN` toggle in operations guide

## Testing
- `pytest -q` *(fails: DetachedInstanceError)*
- `pytest tests/test_admin_tests_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fa4e7b35c832fb7f554e346b5092e