### PR TITLE
feat: harden admin test runner

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -39,9 +39,14 @@ scrape_configs:
 
 ## Admin Test Çalıştırma
 - Endpoint: `POST /api/admin/tests/run` (sadece admin, rate-limit 6/saat)
+- Status: `GET /api/admin/tests/status` (sadece admin) → `{ "allowed": true|false }`
 - Env toggle: `ALLOW_ADMIN_TEST_RUN=true` (default: false)
 - Request body:
 ```json
 { "suite": "unit|smoke|all", "extra": "-k mypattern" }
 ```
 - Response: exit_code, özet, stdout/stderr (kısaltılmış) içerir.
+
+### Güvenlik Sertleştirme
+- Alt süreç çalışma dizini repo kökü ile sınırlandırılmıştır.
+- Alt sürece aktarılan environment beyaz listelidir (PATH, PYTHONPATH, FLASK_ENV vb.). Gizli anahtarlar aktarılmaz.


### PR DESCRIPTION
## Summary
- sandbox admin test execution with safe cwd and env
- expose read-only status endpoint for admin test UI
- surface server toggle on admin tests page

## Testing
- `pytest tests/test_admin_tests_api.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68a0ae646794832fafadc940fb8b762b