### PR TITLE
chore: add security audit workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,35 @@
+name: Security Audit
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install audit deps (curated + tools)
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r .github/audit-requirements.txt
+          python -m pip install --upgrade pip-audit cyclonedx-bom
+      - name: pip check
+        run: pip check
+      - name: pip-audit
+        run: pip-audit -r .github/audit-requirements.txt --progress-spinner=off --strict
+      - name: SBOM (CycloneDX)
+        # SBOM'u tam requirements'tan üret – modül çağrısı ile daha taşınabilir. CLI yoksa fallback.
+        run: python -m cyclonedx_py -r requirements.txt -o sbom.json || cyclonedx-bom -r requirements.txt -o sbom.json
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.json


### PR DESCRIPTION
## Summary
- add security audit workflow with pip-audit and CycloneDX SBOM generation

## Testing
- `pytest -q` *(fails: tests/test_batch_security.py::test_symbol_validation_and_admin_approval - assert 403 == 200, tests/test_batch_security.py::test_admin_grant_then_submit - assert 403 == 200, tests/test_batch_security.py::test_timeframe_asset_guard - AssertionError: assert 403 == 200, tests/test_batch_security.py::test_rate_limit_string_parsing - assert 403 in (200, 429), tests/test_downgrade_task.py::test_downgrade_expired_subscription - celery.exceptions.ImproperlyConfigured:, tests/test_limit_status_api.py::test_limit_status_endpoint - sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <User at 0x7fe6fd172330> is not bound to a Session; lazy load ope..., tests/test_limit_status_api.py::test_limit_status_flag_disabled - sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <User at 0x7fe6fd172330> is not bound to a Session; lazy load ope..., tests/test_limit_status_api.py::test_limit_status_custom_reset_day - sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <User at 0x7fe6fd172330> is not bound to a Session; lazy load ope..., tests/test_plan_tasks.py::test_auto_downgrade_expired_plan - celery.exceptions.ImproperlyConfigured:, tests/test_plan_tasks.py::test_auto_expire_boost - celery.exceptions.ImproperlyConfigured:, tests/test_plan_tasks.py::test_activate_pending_plan - celery.exceptions.ImproperlyConfigured:)*

------
https://chatgpt.com/codex/tasks/task_e_68a324cd2890832fa9f941d0284adeee