### PR TITLE
feat: add billing and auth modules

### DIFF
--- a/app/authx/__init__.py
+++ b/app/authx/__init__.py
@@ -1,0 +1,2 @@
+# package
+

--- a/app/authx/api.py
+++ b/app/authx/api.py
@@ -1,0 +1,172 @@
+import os
+from flask import Blueprint, request, jsonify, current_app
+
+from ..models.db import db, User
+from ..core.security import (
+    PasswordPolicy,
+    get_password_hash,
+    verify_password,
+    create_access_token,
+    create_refresh_token,
+    rotate_refresh_token,
+    record_failed_login,
+    reset_login_failures,
+    is_locked,
+    validate_and_normalize_email,
+    generate_totp_secret,
+    get_totp_uri,
+    verify_totp,
+    decode_token,
+)
+
+bp = Blueprint("authx", __name__)
+
+
+def _json():
+    try:
+        return request.get_json(force=True) or {}
+    except Exception:
+        return {}
+
+
+def _need(fields, data):
+    missing = [f for f in fields if f not in data]
+    return ", ".join(missing) if missing else None
+
+
+def _send_email(to, subject, body):
+    current_app.logger.info("[EMAIL] to=%s subject=%s body=%s", to, subject, body)
+
+
+@bp.post("/register")
+def register():
+    data = _json()
+    miss = _need(["email", "password", "accept_tos"], data)
+    if miss:
+        return jsonify({"detail": f"Missing: {miss}"}), 422
+    email = validate_and_normalize_email(data["email"])
+    ok, msg = PasswordPolicy.validate(data["password"])
+    if not ok:
+        return jsonify({"detail": msg}), 422
+    if not data.get("accept_tos"):
+        return jsonify({"detail": "Terms must be accepted"}), 422
+    if User.query.filter_by(email=email).first():
+        return jsonify({"detail": "Email already registered"}), 409
+    user = User(
+        email=email,
+        password_hash=get_password_hash(data["password"]),
+        email_verified=False,
+    )
+    db.session.add(user)
+    db.session.commit()
+    token = create_access_token(subject=user.id, extra={"t": "email"}, expires_minutes=60 * 24)
+    verify_url = f"{os.getenv('SITE_URL','').rstrip('/')}/api/auth/verify?token={token}"
+    _send_email(email, "Verify your email", f"Click to verify: {verify_url}")
+    return jsonify({"status": "ok"}), 201
+
+
+@bp.get("/verify")
+def verify():
+    token = request.args.get("token")
+    if not token:
+        return jsonify({"detail": "missing token"}), 422
+    try:
+        p = decode_token(token)
+        uid = p["sub"]
+    except Exception:
+        return jsonify({"detail": "invalid token"}), 401
+    user = User.query.get(uid)
+    if not user:
+        return jsonify({"detail": "user not found"}), 404
+    if not user.email_verified:
+        user.email_verified = True
+        db.session.commit()
+    return jsonify({
+        "access": create_access_token(subject=user.id),
+        "refresh": create_refresh_token(subject=user.id),
+    }), 200
+
+
+@bp.post("/login")
+def login():
+    data = _json()
+    miss = _need(["email", "password"], data)
+    if miss:
+        return jsonify({"detail": f"Missing: {miss}"}), 422
+    email = validate_and_normalize_email(data["email"])
+    ident = email
+    if is_locked(ident):
+        return jsonify({"detail": "Account temporarily locked"}), 429
+    user = User.query.filter_by(email=email).first()
+    if not user or not verify_password(data["password"], user.password_hash):
+        cnt = record_failed_login(ident)
+        return jsonify({"detail": "Invalid credentials", "attempts": cnt}), 401
+    if user.totp_secret:
+        if not data.get("totp_code") or not verify_totp(data["totp_code"], user.totp_secret):
+            return jsonify({"detail": "TOTP required/invalid"}), 401
+    reset_login_failures(ident)
+    return jsonify(
+        {
+            "access": create_access_token(subject=user.id),
+            "refresh": create_refresh_token(subject=user.id),
+        }
+    ), 200
+
+
+@bp.post("/refresh")
+def refresh():
+    data = _json()
+    if "refresh" not in data:
+        return jsonify({"detail": "Missing: refresh"}), 422
+    try:
+        new_r = rotate_refresh_token(data["refresh"])
+        p = decode_token(new_r, require_type="refresh")
+        return (
+            jsonify({"access": create_access_token(subject=p["sub"]), "refresh": new_r}),
+            200,
+        )
+    except Exception:
+        return jsonify({"detail": "invalid refresh"}), 401
+
+
+@bp.post("/logout")
+def logout():
+    from ..core.security import revoke_token
+
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        try:
+            p = decode_token(auth.split(" ", 1)[1])
+            revoke_token(p["jti"], p["exp"])
+        except Exception:
+            pass
+    data = _json()
+    if data.get("refresh"):
+        try:
+            p = decode_token(data["refresh"], require_type="refresh")
+            revoke_token(p["jti"], p["exp"])
+        except Exception:
+            pass
+    return jsonify({"status": "ok"}), 200
+
+
+@bp.post("/totp/setup")
+def totp_setup():
+    data = _json()
+    if "access" not in data:
+        return jsonify({"detail": "Missing: access"}), 422
+    try:
+        p = decode_token(data["access"], require_type="access")
+    except Exception:
+        return jsonify({"detail": "invalid token"}), 401
+    user = User.query.get(p["sub"])
+    if not user:
+        return jsonify({"detail": "user not found"}), 404
+    if user.totp_secret:
+        return jsonify({"detail": "already enabled"}), 409
+    secret = generate_totp_secret()
+    user.totp_secret = secret
+    db.session.commit()
+    uri = get_totp_uri(user.email, secret)
+    return jsonify({"otpauth_uri": uri}), 200
+

--- a/app/auto_register.py
+++ b/app/auto_register.py
@@ -1,0 +1,28 @@
+from flask import Blueprint
+from .models.db import ensure_db_and_tables, seed_plans
+
+
+def _has_prefix(app, prefix: str) -> bool:
+    """Uygulamada verilen prefix ile kayıtlı blueprint var mı?"""
+    for rule in app.url_map.iter_rules():
+        if str(rule.rule).startswith(prefix.rstrip("/")):
+            return True
+    return False
+
+
+def _register_if_missing(app, bp: Blueprint, prefix: str) -> None:
+    """Prefix mevcut değilse blueprint'i kaydet."""
+    if not _has_prefix(app, prefix):
+        app.register_blueprint(bp, url_prefix=prefix)
+
+
+def register_all(app) -> None:
+    """Blueprint'leri ve tabloları otomatik bağla (idempotent)."""
+    ensure_db_and_tables(app)
+    seed_plans(app)
+    from .authx.api import bp as auth_bp
+    from .billing.api import bp as billing_bp
+
+    _register_if_missing(app, auth_bp, "/api/auth")
+    _register_if_missing(app, billing_bp, "/api/billing")
+

--- a/app/billing/__init__.py
+++ b/app/billing/__init__.py
@@ -1,0 +1,2 @@
+# package
+

--- a/app/billing/api.py
+++ b/app/billing/api.py
@@ -1,0 +1,177 @@
+import os
+from datetime import datetime
+
+from flask import Blueprint, request, jsonify, current_app
+
+from ..models.db import db, Plan, Customer, Subscription, Invoice, User
+from ..core.security import decode_token, _redis_client
+from .providers import get_provider
+
+bp = Blueprint("billing", __name__)
+
+
+def _json():
+    try:
+        return request.get_json(force=True) or {}
+    except Exception:
+        return {}
+
+
+def _auth_user():
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return None
+    try:
+        p = decode_token(auth.split(" ", 1)[1], require_type="access")
+        return User.query.get(p["sub"])
+    except Exception:
+        return None
+
+
+@bp.get("/plans")
+def plans():
+    rows = Plan.query.filter_by(active=True).all()
+    return (
+        jsonify(
+            [
+                {
+                    "code": r.code,
+                    "price_minor": r.price_minor,
+                    "currency": r.currency,
+                    "interval": r.interval,
+                }
+                for r in rows
+            ]
+        ),
+        200,
+    )
+
+
+def _ensure_customer(user, provider):
+    cust = Customer.query.filter_by(user_id=user.id, provider=provider.name).first()
+    if cust:
+        return cust
+    provider_customer_id = f"{provider.name}:{user.id}"
+    cust = Customer(
+        user_id=user.id,
+        provider=provider.name,
+        provider_customer_id=provider_customer_id,
+    )
+    db.session.add(cust)
+    db.session.commit()
+    return cust
+
+
+@bp.post("/checkout")
+def checkout():
+    user = _auth_user()
+    if not user:
+        return jsonify({"detail": "unauthorized"}), 401
+    data = _json()
+    plan = Plan.query.filter_by(code=data.get("plan_code"), active=True).first()
+    if not plan:
+        return jsonify({"detail": "plan not found"}), 404
+    provider = get_provider()
+    # Stripe: ilk alışverişte customer yaratmasın diye boş bırakıyoruz,
+    # webhook’ta gelen customer id ile mapping oluşturacağız.
+    cust = Customer.query.filter_by(user_id=user.id, provider=provider.name).first()
+    customer_id = cust.provider_customer_id if cust else None
+    site = os.getenv("SITE_URL", "").rstrip("/")
+    succ = site + (os.getenv("CHECKOUT_SUCCESS_PATH") or "/billing/success")
+    canc = site + (os.getenv("CHECKOUT_CANCEL_PATH") or "/billing/cancel")
+    sess = provider.create_checkout_session(
+        customer_id=customer_id,
+        plan={
+            "code": plan.code,
+            "price_minor": plan.price_minor,
+            "currency": plan.currency,
+            "interval": plan.interval,
+        },
+        success_url=succ,
+        cancel_url=canc,
+        metadata={
+            "user_id": str(user.id),
+            "plan_code": plan.code,
+        },
+    )
+    return jsonify({"redirect_url": sess.url}), 200
+
+
+@bp.post("/portal")
+def portal():
+    user = _auth_user()
+    if not user:
+        return jsonify({"detail": "unauthorized"}), 401
+    provider = get_provider()
+    cust = Customer.query.filter_by(user_id=user.id, provider=provider.name).first()
+    if not cust:
+        return jsonify({"detail": "no customer"}), 404
+    site = os.getenv("SITE_URL", "").rstrip("/")
+    ret = site + (os.getenv("PORTAL_RETURN_PATH") or "/billing")
+    sess = provider.create_billing_portal(
+        customer_id=cust.provider_customer_id, return_url=ret
+    )
+    return jsonify({"redirect_url": sess.url}), 200
+
+
+@bp.post("/webhook")
+def webhook():
+    provider = get_provider()
+    payload = request.get_data()
+    sig = request.headers.get("Stripe-Signature") or ""
+    try:
+        ev_type, data, event_id = provider.verify_and_parse_webhook(
+            payload=payload, sig_header=sig
+        )
+    except Exception as e:
+        current_app.logger.warning("Webhook verify failed: %s", e)
+        return jsonify({"detail": "invalid"}), 400
+    # idempotency
+    key = f"billing:webhook:{event_id}"
+    r = _redis_client()
+    if not r.setnx(key, "1"):
+        return jsonify({"status": "duplicate"}), 200
+    r.expire(key, 60 * 60 * 24 * 3)
+
+    current_app.logger.info("Webhook %s %s", ev_type, event_id)
+    if ev_type == "checkout.session.completed":
+        cust_id = data.get("customer")
+        sub_id = data.get("subscription")
+        meta = data.get("metadata") or {}
+        plan_code = meta.get("plan_code")
+        user_id = meta.get("user_id")
+        if not (cust_id and sub_id and plan_code and user_id):
+            current_app.logger.warning("checkout.completed missing fields")
+            return jsonify({"status":"ignored"}), 200
+        # Customer mapping yoksa oluştur
+        cust = Customer.query.filter_by(provider=provider.name, provider_customer_id=cust_id).first()
+        if not cust:
+            cust = Customer(user_id=user_id, provider=provider.name, provider_customer_id=cust_id)
+            db.session.add(cust); db.session.commit()
+        plan = Plan.query.filter_by(code=plan_code).first()
+        if plan:
+            sub = Subscription.query.filter_by(provider=provider.name, provider_sub_id=sub_id).first()
+            if not sub:
+                db.session.add(Subscription(
+                    user_id=cust.user_id, plan_id=plan.id, provider=provider.name,
+                    provider_sub_id=sub_id, status="active"
+                ))
+                db.session.commit()
+    elif ev_type == "invoice.paid":
+        uid = (
+            Customer.query.filter_by(
+                provider_customer_id=data["customer"], provider=provider.name
+            ).first().user_id
+        )
+        inv = Invoice(
+            user_id=uid,
+            provider_invoice_id=data["id"],
+            amount_minor=data["amount_paid"],
+            currency=data["currency"],
+            status="paid",
+            hosted_url=data.get("hosted_invoice_url"),
+            pdf_url=data.get("invoice_pdf"),
+        )
+        db.session.add(inv)
+        db.session.commit()
+    return jsonify({"status": "ok"}), 200

--- a/app/billing/providers/__init__.py
+++ b/app/billing/providers/__init__.py
@@ -1,0 +1,12 @@
+import os
+
+from .stripe_provider import StripeProvider
+from .stub_craftgate import CraftgateProvider
+
+
+def get_provider():
+    name = (os.getenv("BILLING_PROVIDER") or "stripe").lower()
+    if name == "stripe":
+        return StripeProvider()
+    if name == "craftgate":
+        return CraftgateProvider()

--- a/app/billing/providers/base.py
+++ b/app/billing/providers/base.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Optional, Dict, Any, Mapping
+
+
+@dataclass
+class CheckoutSession:
+    url: str
+
+
+@dataclass
+class BillingPortal:
+    url: str
+
+
+class BillingProvider:
+    name: str = "base"
+
+    def create_checkout_session(
+        self,
+        *,
+        customer_id: Optional[str],
+        plan: Dict[str, Any],
+        success_url: str,
+        cancel_url: str,
+        metadata: Optional[Mapping[str, str]] = None,
+    ) -> CheckoutSession:
+        raise NotImplementedError
+
+    def create_billing_portal(self, *, customer_id: str, return_url: str) -> BillingPortal:
+        raise NotImplementedError
+
+    def verify_and_parse_webhook(self, *, payload: bytes, sig_header: str):
+        """Return (event_type:str, data:dict, event_id:str)."""
+        raise NotImplementedError
+

--- a/app/billing/providers/stripe_provider.py
+++ b/app/billing/providers/stripe_provider.py
@@ -1,0 +1,53 @@
+import os
+
+import stripe
+
+from .base import BillingProvider, CheckoutSession, BillingPortal
+
+
+class StripeProvider(BillingProvider):
+    name = "stripe"
+
+    def __init__(self):
+        sk = os.getenv("STRIPE_SECRET_KEY")
+        if not sk:
+            raise RuntimeError("STRIPE_SECRET_KEY not set")
+        stripe.api_key = sk
+
+    def create_checkout_session(self, *, customer_id, plan, success_url, cancel_url, metadata=None) -> CheckoutSession:
+        interval = plan["interval"]
+        unit_amount = plan["price_minor"]
+        currency = plan["currency"].lower()
+        params = {
+            "mode": "subscription",
+            "success_url": success_url + "?session_id={CHECKOUT_SESSION_ID}",
+            "cancel_url": cancel_url,
+            "line_items": [
+                {
+                    "price_data": {
+                        "currency": currency,
+                        "product_data": {"name": plan["code"]},
+                        "unit_amount": unit_amount,
+                        "recurring": {"interval": interval},
+                    },
+                    "quantity": 1,
+                }
+            ],
+            "allow_promotion_codes": True,
+        }
+        if metadata:
+            params["metadata"] = dict(metadata)
+        if customer_id:
+            params["customer"] = customer_id
+        sess = stripe.checkout.Session.create(**params)
+        return CheckoutSession(url=sess.url)
+
+    def create_billing_portal(self, *, customer_id: str, return_url: str) -> BillingPortal:
+        sess = stripe.billing_portal.Session.create(customer=customer_id, return_url=return_url)
+        return BillingPortal(url=sess.url)
+
+    def verify_and_parse_webhook(self, *, payload: bytes, sig_header: str):
+        secret = os.getenv("STRIPE_WEBHOOK_SECRET")
+        event = stripe.Webhook.construct_event(payload=payload, sig_header=sig_header, secret=secret)
+        return event["type"], event["data"]["object"], event["id"]
+

--- a/app/billing/providers/stub_craftgate.py
+++ b/app/billing/providers/stub_craftgate.py
@@ -1,0 +1,24 @@
+import os
+
+from .base import BillingProvider, CheckoutSession, BillingPortal
+
+
+class CraftgateProvider(BillingProvider):
+    """İskelet – gerçek Craftgate entegrasyonu için SDK çağrılarını ekleyin."""
+
+    name = "craftgate"
+
+    def __init__(self):
+        if not os.getenv("CRAFTGATE_API_KEY"):
+            raise RuntimeError("CRAFTGATE_API_KEY not set")
+
+    def create_checkout_session(self, *, customer_id, plan, success_url, cancel_url, metadata=None):
+        url = success_url + "?mock=cg"
+        return CheckoutSession(url=url)
+
+    def create_billing_portal(self, *, customer_id: str, return_url: str) -> BillingPortal:
+        return BillingPortal(url=return_url)
+
+    def verify_and_parse_webhook(self, *, payload: bytes, sig_header: str):
+        return "subscription.updated", {}, "mock-event-id"
+

--- a/app/models/db.py
+++ b/app/models/db.py
@@ -1,0 +1,114 @@
+import os
+from datetime import datetime
+from uuid import uuid4
+
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.exc import OperationalError
+
+
+db: SQLAlchemy = SQLAlchemy(session_options={"autoflush": False})
+
+
+class User(db.Model):
+    __tablename__ = "auth_users"
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid4()))
+    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
+    password_hash = db.Column(db.String(255), nullable=False)
+    email_verified = db.Column(db.Boolean, default=False, nullable=False)
+    totp_secret = db.Column(db.String(64), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class Plan(db.Model):
+    __tablename__ = "plans"
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid4()))
+    code = db.Column(db.String(64), unique=True, nullable=False, index=True)
+    price_minor = db.Column(db.Integer, nullable=False)
+    currency = db.Column(db.String(8), nullable=False, default="TRY")
+    interval = db.Column(db.String(16), nullable=False, default="month")
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    limits_json = db.Column(JSONB, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class Customer(db.Model):
+    __tablename__ = "customers"
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid4()))
+    user_id = db.Column(db.String(36), db.ForeignKey("auth_users.id"), nullable=False, index=True)
+    provider = db.Column(db.String(32), nullable=False)
+    provider_customer_id = db.Column(db.String(128), nullable=False, index=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class Subscription(db.Model):
+    __tablename__ = "subscriptions"
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid4()))
+    user_id = db.Column(db.String(36), db.ForeignKey("auth_users.id"), nullable=False, index=True)
+    plan_id = db.Column(db.String(36), db.ForeignKey("plans.id"), nullable=False)
+    provider = db.Column(db.String(32), nullable=False)
+    provider_sub_id = db.Column(db.String(128), nullable=False, index=True)
+    status = db.Column(db.String(32), nullable=False)
+    current_period_end = db.Column(db.DateTime, nullable=True)
+    cancel_at_period_end = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class Invoice(db.Model):
+    __tablename__ = "invoices"
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid4()))
+    user_id = db.Column(db.String(36), db.ForeignKey("auth_users.id"), nullable=False, index=True)
+    provider_invoice_id = db.Column(db.String(128), nullable=False, index=True)
+    amount_minor = db.Column(db.Integer, nullable=False)
+    currency = db.Column(db.String(8), nullable=False)
+    status = db.Column(db.String(32), nullable=False)
+    hosted_url = db.Column(db.String(512), nullable=True)
+    pdf_url = db.Column(db.String(512), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+def _attach_db(app):
+    """Flask uygulamasına SQLAlchemy örneğini bağla."""
+    if "sqlalchemy" in app.extensions:
+        return app.extensions["sqlalchemy"].db
+    uri = app.config.get("SQLALCHEMY_DATABASE_URI") or os.getenv("DATABASE_URL")
+    app.config.setdefault("SQLALCHEMY_DATABASE_URI", uri)
+    app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
+    db.init_app(app)
+    return db
+
+
+def ensure_db_and_tables(app) -> None:
+    """Veritabanını ve tabloları oluştur."""
+    _attach_db(app)
+    try:
+        with app.app_context():
+            db.create_all()
+    except OperationalError:
+        # DB yoksa uygulama yine kalksın
+        pass
+
+
+def seed_plans(app) -> None:
+    """SEED_PLANS ortam değişkeninden plan verilerini ekle."""
+    seeds = (os.getenv("SEED_PLANS") or "").strip()
+    if not seeds:
+        return
+    with app.app_context():
+        for item in seeds.split(","):
+            try:
+                code, price, curr, interval = item.split(":")
+            except ValueError:
+                continue
+            exists = Plan.query.filter_by(code=code).first()
+            if not exists:
+                db.session.add(
+                    Plan(
+                        code=code,
+                        price_minor=int(price),
+                        currency=curr,
+                        interval=interval,
+                    )
+                )
+        db.session.commit()
+

--- a/app/secure_app.py
+++ b/app/secure_app.py
@@ -10,7 +10,9 @@ gunicorn örneği:
 import importlib
 import os
 from typing import Optional
+
 from app.security_bootstrap import bootstrap_security
+from app.auto_register import register_all
 
 def _resolve_candidate(spec: str):
     mod, _, attr = spec.partition(":")
@@ -42,4 +44,7 @@ def _load_app_from_candidates() -> Optional[object]:
 # Gerçek uygulamayı çözüp güvenlik katmanlarını uygula
 _real_app = _load_app_from_candidates()
 app = bootstrap_security(_real_app)
+
+# Otomatik blueprint ve veritabanı kayıtları
+register_all(app)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,3 +154,7 @@ argon2-cffi==23.1.0
 
 # PyJWT pin (flask_jwt_extended uyumu için)
 PyJWT==2.8.0
+stripe==8.10.0
+#
+# Not: Craftgate için projede stub provider kullanıyoruz (app/billing/providers/stub_craftgate.py).
+# Resmi bir Python SDK/PyPI paketi bulunmadığından craftgate bağımlılığını eklemiyoruz.


### PR DESCRIPTION
## Summary
- enrich billing providers with metadata support for checkout sessions
- defer customer creation until webhook handling with idempotency safeguards
- clarify Craftgate stub usage by removing unused dependency

## Testing
- `pytest` *(error: unrecognized arguments: --cov=backend --cov-report=term-missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a434203ff8832face834dbef991b3a