### PR TITLE
Add security headers and session cookie protections

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,9 @@
 from flask import Flask
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+import bleach
 from backend.utils.logger import create_log
+from .core.error_handlers import register_error_handlers
 
 
 def create_app() -> Flask:
@@ -21,6 +23,24 @@ def create_app() -> Flask:
         """Login denemeleri için özel limit; gerçek iş mantığı ayrı blueprint'te."""
         create_log(action="login_rate_limit", endpoint="/api/auth/login")
         return "", 204
+
+    register_error_handlers(app)
+
+    @app.after_request
+    def set_security_headers(response):
+        """Temel güvenlik başlıklarını ayarla"""
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+        return response
+
+    @app.template_filter("sanitize")
+    def sanitize_html(text: str) -> str:
+        """HTML içeriğini XSS'e karşı temizle"""
+        if not text:
+            return ""
+        allowed = {"a": ["href", "title"]}
+        return bleach.clean(text, tags=["p", "br", "strong", "em", "u", "a"], attributes=allowed, strip=True)
 
     return app
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+from datetime import timedelta
 
 
 class Config:
@@ -10,4 +11,11 @@ class Config:
         if os.environ.get("FLASK_ENV") == "production":
             raise ValueError("SECRET_KEY must be set in production")
         SECRET_KEY = secrets.token_urlsafe(32)
+
+    # Oturum güvenliği
+    SESSION_COOKIE_NAME = "session"
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SAMESITE = "Lax"
+    SESSION_COOKIE_SECURE = os.environ.get("FLASK_ENV") == "production"
+    PERMANENT_SESSION_LIFETIME = timedelta(hours=4)
 

--- a/app/core/error_handlers.py
+++ b/app/core/error_handlers.py
@@ -1,0 +1,18 @@
+from flask import jsonify
+from sqlalchemy.exc import SQLAlchemyError
+
+
+def register_error_handlers(app):
+    """Global hata yakalama"""
+
+    @app.errorhandler(500)
+    def internal_error(error):
+        from ..models.db import db
+        db.session.rollback()
+        return jsonify({"error": "Internal Server Error"}), 500
+
+    @app.errorhandler(SQLAlchemyError)
+    def handle_db_error(error):
+        from ..models.db import db
+        db.session.rollback()
+        return jsonify({"error": "Database Error"}), 500


### PR DESCRIPTION
## Summary
- add basic security headers and HTML sanitization filter
- configure secure session cookie settings
- register minimal global error handlers

## Testing
- `pytest` *(fails: assert 403 == 200; celery.exceptions.ImproperlyConfigured; DetachedInstanceError)*

------
https://chatgpt.com/codex/tasks/task_e_68a611052068832fa01cd39afa02c2db