### PR TITLE
Add email verification token support

### DIFF
--- a/app/authx/api.py
+++ b/app/authx/api.py
@@ -9,6 +9,7 @@ from ..core.security import (
     get_password_hash,
     verify_password,
     create_access_token,
+    create_email_token,
     create_refresh_token,
     rotate_refresh_token,
     record_failed_login,
@@ -83,7 +84,7 @@ def register():
     )
     db.session.add(user)
     db.session.commit()
-    token = create_access_token(subject=user.id, extra={"t": "email"}, expires_minutes=60 * 24)
+    token = create_email_token(subject=user.id, expires_minutes=60 * 24)
     verify_url = f"{os.getenv('SITE_URL','').rstrip('/')}/api/auth/verify?token={token}"
     _send_email(email, "Verify your email", f"Click to verify: {verify_url}")
     return jsonify({"status": "ok"}), 201
@@ -95,7 +96,7 @@ def verify():
     if not token:
         return jsonify({"detail": "missing token"}), 422
     try:
-        p = decode_token(token)
+        p = decode_token(token, require_type="email")
         uid = p["sub"]
     except Exception:
         return jsonify({"detail": "invalid token"}), 401

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -349,6 +349,21 @@ def create_refresh_token(subject: str, extra: Optional[Dict[str, Any]] = None, e
         claims.update(extra)
     return _encode_jwt(claims, version=ver)
 
+def create_email_token(subject: str, expires_minutes: Optional[int] = None) -> str:
+    """E-posta doğrulama tokenı üret."""
+    ver = int(os.getenv("JWT_KEY_VERSION", "1"))
+    exp_m = int(expires_minutes or os.getenv("EMAIL_TOKEN_EXPIRES_MINUTES", str(60 * 24)))
+    now = datetime.now(timezone.utc)
+    claims: Dict[str, Any] = {
+        "sub": str(subject),
+        "iat": int(now.timestamp()),
+        "exp": int(_jwt_exp(exp_m).timestamp()),
+        "jti": uuid.uuid4().hex,
+        "t": "email",
+        "ver": ver,
+    }
+    return _encode_jwt(claims, version=ver)
+
 def generate_tokens(user_id: str) -> Tuple[str, str]:
     """Belirtilen kullanıcı için access ve refresh token üret."""
     access = create_access_token(subject=str(user_id))

--- a/tests/test_email_token.py
+++ b/tests/test_email_token.py
@@ -1,0 +1,28 @@
+import os
+import pathlib
+import importlib.util
+import pytest
+
+# Güvenlik modülünü uygulama paketi yüklenmeden dinamik olarak yükle
+SECURITY_PATH = pathlib.Path(__file__).resolve().parents[1] / "app" / "core" / "security.py"
+spec = importlib.util.spec_from_file_location("security", SECURITY_PATH)
+security = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(security)
+
+
+def test_create_email_token_and_decode(monkeypatch):
+    # Ortamı test moduna ayarlıyoruz
+    monkeypatch.setenv("SECRET_PROVIDER", "env")
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    # Redis istemcisini sahte nesne ile değiştiriyoruz
+    class _DummyRedis:
+        def exists(self, key):
+            return 0
+    security._redis_client = lambda: _DummyRedis()
+
+    token = security.create_email_token(subject="42")
+    payload = security.decode_token(token, require_type="email")
+    assert payload["sub"] == "42"
+
+    with pytest.raises(security.HTTPException):
+        security.decode_token(token, require_type="access")


### PR DESCRIPTION
## Summary
- add dedicated email token generation in security module
- use email token during registration and verification flows
- cover email token encode/decode with tests

## Testing
- `pytest tests/test_email_token.py`
- `pytest` *(fails: test_batch_security::test_symbol_validation_and_admin_approval, test_batch_security::test_admin_grant_then_submit, test_batch_security::test_timeframe_asset_guard, test_batch_security::test_rate_limit_string_parsing, test_downgrade_task::test_downgrade_expired_subscription, test_limit_status_api::test_limit_status_endpoint, test_limit_status_api::test_limit_status_flag_disabled, test_limit_status_api::test_limit_status_custom_reset_day, test_plan_tasks::test_auto_downgrade_expired_plan, test_plan_tasks::test_auto_expire_boost, test_plan_tasks::test_activate_pending_plan)*

------
https://chatgpt.com/codex/tasks/task_e_68a62d818974832f8d1334dcac1e906c