### PR TITLE
Add plan-based rate limiting and usage tracking

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -24,13 +24,13 @@ from backend.constants import SUBSCRIPTION_EXTENSION_DAYS
 
 # Güvenlik dekoratörlerini import et
 from backend.utils.decorators import require_subscription_plan
-from backend.utils.usage_limits import check_usage_limit
+from backend.utils.usage_limits import check_usage_limit, get_usage_status
 
 # Yardımcı fonksiyonları import et
 from backend.utils.helpers import serialize_user_for_api, add_audit_log
-from backend.utils.plan_limits import get_user_effective_limits
+from backend.utils.plan_limits import get_user_effective_limits, get_all_feature_keys
 from backend.middleware.plan_limits import enforce_plan_limit
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import jwt_required, get_jwt_identity
 
 # API Blueprint'i tanımla
 api_bp = Blueprint('api', __name__)
@@ -47,6 +47,40 @@ BACKEND_PLAN_PRICES = {
     SubscriptionPlan.ADVANCED.name: 24.99,
     SubscriptionPlan.PREMIUM.name: 49.99
 }
+
+# ---------------------------------------------------------------------------
+# Limit durumu (UI yardımcı)
+# ---------------------------------------------------------------------------
+@api_bp.route('/limits/status', methods=['GET'])
+@jwt_required()
+def limits_status():
+    try:
+        uid = str(get_jwt_identity())
+        user = User.query.get(uid)
+        if not user:
+            return jsonify({"error": "User not found"}), 404
+
+        feature_keys = get_all_feature_keys()
+        status = {fk: get_usage_status(uid, fk) for fk in feature_keys}
+
+        try:
+            create_log(
+                user_id=uid,
+                username=user.username,
+                ip_address=request.remote_addr or "unknown",
+                action="limits_status",
+                target="/api/limits/status",
+                description="Kullanım limit durumu sorgulandı.",
+                status="success",
+                user_agent=request.headers.get("User-Agent", ""),
+            )
+        except Exception as log_err:
+            logger.warning(f"limits_status log oluşturulamadı: {log_err}")
+
+        return jsonify({"plan": str(user.subscription_level), "features": status}), 200
+    except Exception as e:
+        logger.error(f'limits_status error: {e}')
+        return jsonify({"error": "Failed to fetch limit status"}), 500
 
 # Analiz endpoint'i
 @api_bp.route('/analyze_coin/<string:coin_id>', methods=['GET', 'POST'])
@@ -603,8 +637,8 @@ def get_user_profile():
     user = g.user
     daily_usage = DailyUsage.query.filter_by(user_id=user.id, date=date.today()).first()
     used = daily_usage.analyze_calls if daily_usage else 0
-    limits = get_user_effective_limits(user)
-    max_daily = limits.get('coin_analysis') or limits.get('max_prediction_per_day')
+    eff = get_user_effective_limits(user_id=str(user.id), feature_key="coin_analysis")
+    max_daily = eff.get('daily_quota')
     remaining = None
     if isinstance(max_daily, int) or isinstance(max_daily, float):
         remaining = max(max_daily - used, 0)
@@ -613,7 +647,8 @@ def get_user_profile():
         'user': user_data,
         'limits': {
             'used_prediction_today': used,
-            'remaining_prediction_today': remaining
+            'remaining_prediction_today': remaining,
+            'daily_quota': max_daily
         },
         'plan': user.plan.to_dict() if user.plan else None
     }), 200

--- a/backend/limiting.py
+++ b/backend/limiting.py
@@ -1,17 +1,67 @@
+# backend/limiting.py
+"""Plan-bazlı dinamik rate-limit yardımcıları.
+
+Flask-Limiter için kullanıcının planından türetilen burst-per-minute değeri
+üretir. Kullanıcı bulunamazsa güvenli bir IP fallback değeri döner.
+"""
+from __future__ import annotations
+
+from typing import Optional
+from flask import g, request
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
-from flask import g, request
-from backend.db.models import User
 
-limiter = Limiter(get_remote_address)
+try:  # Projenizde olabilir / olmayabilir
+    from flask_jwt_extended import get_jwt_identity  # type: ignore
+except Exception:  # pragma: no cover
+    get_jwt_identity = None  # type: ignore
+
+from backend.utils.plan_limits import get_user_effective_limits
 
 
-def get_plan_rate_limit():
-    api_key = request.headers.get("X-API-KEY")
-    user = None
+limiter = Limiter(key_func=get_remote_address)
+
+
+def _resolve_user_id() -> Optional[str]:
+    """g.user ya da JWT'den kullanıcı kimliği çöz."""
+    try:
+        if hasattr(g, "user") and getattr(g.user, "id", None):
+            return str(g.user.id)
+    except Exception:
+        pass
+
+    if get_jwt_identity is not None:
+        try:
+            uid = get_jwt_identity()
+            if uid:
+                return str(uid)
+        except Exception:
+            pass
+    return None
+
+
+def get_plan_rate_limit() -> str:
+    """Flask‑Limiter için limit string'i döndür (örn. "60 per minute")."""
+    user_id = _resolve_user_id()
+    feature_key = "global_api"
+
+    # Güvenli varsayılan: 30/dk (kullanıcı yoksa IP bazlı uygulanacak)
+    default_burst = 30
+
+    try:
+        if user_id:
+            eff = get_user_effective_limits(user_id=user_id, feature_key=feature_key)
+            burst = int(eff.get("burst_per_minute") or default_burst)
+            return f"{max(1, burst)} per minute"
+    except Exception:
+        pass
+
+    return f"{default_burst} per minute"
+
+
+def rate_limit_key_func() -> str:
+    """Limiter key: varsa API key; yoksa uzak IP."""
+    api_key = request.headers.get("X-API-KEY") or request.args.get("api_key")
     if api_key:
-        user = User.query.filter_by(api_key=api_key).first()
-    if not user or not user.plan:
-        return "30/minute"
-    limits = user.plan.features_dict()
-    return f"{limits.get('api_rate_limit_per_minute', 30)}/minute"
+        return f"api:{api_key}"
+    return request.remote_addr or "unknown"

--- a/backend/utils/usage_limits.py
+++ b/backend/utils/usage_limits.py
@@ -1,85 +1,158 @@
+# backend/utils/usage_limits.py
+from __future__ import annotations
+
 from functools import wraps
-from flask import g, request, jsonify, current_app
-from datetime import datetime
+from typing import Callable, Dict, Optional
+from datetime import datetime, timedelta, date
 
-from backend.db.models import UsageLimitModel, SubscriptionPlan, UsageLog
+from flask import jsonify, g, current_app
+
+from backend.utils.plan_limits import get_user_effective_limits
 
 
-def check_usage_limit(feature_name):
-    """Enforces daily and monthly usage limits for a feature."""
+def _resolve_user():
+    try:
+        from backend.db.models import User  # local import (döngü engelle)
+        if hasattr(g, "user") and isinstance(getattr(g, "user", None), User):
+            return g.user
+    except Exception:
+        pass
+    try:
+        from flask_jwt_extended import get_jwt_identity  # type: ignore
+        from backend.db.models import User
+        uid = get_jwt_identity()
+        if uid:
+            return User.query.get(uid)
+    except Exception:
+        pass
+    return None
 
-    def decorator(f):
+
+def _r():
+    return current_app.extensions.get("redis_client")
+
+
+def _today() -> str:
+    return date.today().strftime("%Y%m%d")
+
+
+def _rk(uid: str, fk: str) -> str:
+    return f"usage:{uid}:{fk}:{_today()}"
+
+
+def _ttl_midnight() -> int:
+    now = datetime.utcnow()
+    tomorrow = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    return max(60, int((tomorrow - now).total_seconds()))
+
+
+def _inc_r(uid: str, fk: str) -> int:
+    r = _r()
+    if not r:
+        return -1
+    key = _rk(uid, fk)
+    pipe = r.pipeline()
+    pipe.incr(key, 1)
+    pipe.expire(key, _ttl_midnight())
+    val, _ = pipe.execute()
+    try:
+        return int(val)
+    except Exception:
+        return -1
+
+
+def _get_r(uid: str, fk: str) -> Optional[int]:
+    r = _r()
+    if not r:
+        return None
+    v = r.get(_rk(uid, fk))
+    return int(v) if v is not None else 0
+
+
+def _inc_db(uid: str, fk: str) -> int:
+    from backend.db.models import db, DailyUsage  # local import
+    row = DailyUsage.query.filter_by(user_id=uid, feature_key=fk, usage_date=date.today()).first()
+    if not row:
+        row = DailyUsage(user_id=uid, feature_key=fk, usage_date=date.today(), used_count=0)
+        db.session.add(row)
+    row.used_count = (row.used_count or 0) + 1
+    db.session.commit()
+    return int(row.used_count)
+
+
+def _get_db(uid: str, fk: str) -> int:
+    from backend.db.models import DailyUsage  # local import
+    row = DailyUsage.query.filter_by(user_id=uid, feature_key=fk, usage_date=date.today()).first()
+    return int(row.used_count) if row else 0
+
+
+def _payload(used: int, quota: int) -> Dict:
+    remaining = max(0, quota - used)
+    pct = (used / quota) if quota > 0 else 0.0
+    return {
+        "used": used,
+        "quota": quota,
+        "remaining": remaining,
+        "percent": round(pct, 4),
+        "warn75": pct >= 0.75,
+        "warn90": pct >= 0.90,
+        "exhausted": used >= quota,
+    }
+
+
+def check_usage_limit(feature_key: str) -> Callable:
+    """Endpoint decorator: günlük kotayı uygular (Redis → DB fallback)."""
+
+    def deco(f):
         @wraps(f)
-        def wrapper(*args, **kwargs):
-            user = getattr(g, "user", None)
+        def wrapped(*args, **kwargs):
+            user = _resolve_user()
             if not user:
-                api_key = request.headers.get("X-API-KEY")
-                if api_key:
-                    user = User.query.filter_by(api_key=api_key).first()
-                    if user:
-                        g.user = user
-            if not user:
-                return jsonify({"error": "Yetkilendirme hatası"}), 401
+                return jsonify({"error": "Unauthorized"}), 401
 
-            plan_name = user.subscription_level.name.upper()
+            eff = get_user_effective_limits(user_id=str(user.id), feature_key=feature_key)
+            quota = int(eff.get("daily_quota", 0))
 
-            # Premium veya sınırsız planlar için kısıtlama yok
-            if plan_name in ["PREMIUM", "UNLIMITED"]:
+            used = _inc_r(str(user.id), feature_key)
+            if used < 0:
+                used = _inc_db(str(user.id), feature_key)
+
+            if used > quota > 0:
+                pl = _payload(used, quota)
+                pl.update({
+                    "feature_key": feature_key,
+                    "plan_name": eff.get("plan_name"),
+                    "message": "Günlük kullanım kotanız doldu",
+                })
+                return jsonify({"error": "LimitExceeded", "limit": pl}), 429
+
+            # İsteğe bağlı telemetri header'ları
+            try:
+                from flask import make_response
+                resp = f(*args, **kwargs)
+                if isinstance(resp, tuple):
+                    body, *rest = resp
+                    response = make_response(body, *(rest or []))
+                else:
+                    response = make_response(resp)
+                pl = _payload(used, quota)
+                response.headers["X-Usage-Used"] = str(pl["used"])
+                response.headers["X-Usage-Quota"] = str(pl["quota"])
+                response.headers["X-Usage-Remaining"] = str(pl["remaining"])
+                return response
+            except Exception:
                 return f(*args, **kwargs)
 
-            # Limiti veritabanından çek
-            limit = UsageLimitModel.query.filter_by(
-                plan_name=plan_name, feature=feature_name
-            ).first()
-            if not limit:
-                return (
-                    jsonify({"error": f"{feature_name} için kullanım limiti tanımlanmamış."}),
-                    403,
-                )
+        return wrapped
 
-            redis_client = current_app.extensions.get("redis_client")
-            if not redis_client:
-                return jsonify({"error": "Rate kontrol altyapısı pasif."}), 500
-
-            now = datetime.utcnow()
-            day_key = f"usage:{user.id}:{feature_name}:day:{now.strftime('%Y%m%d')}"
-            month_key = f"usage:{user.id}:{feature_name}:month:{now.strftime('%Y%m')}"
-
-            daily_count = int(redis_client.get(day_key) or 0)
-            monthly_count = int(redis_client.get(month_key) or 0)
-
-            if limit.daily_limit is not None and daily_count >= limit.daily_limit:
-                return (
-                    jsonify({"error": f"Günlük limit aşıldı: {limit.daily_limit} / {feature_name}"}),
-                    429,
-                )
-
-            if limit.monthly_limit is not None and monthly_count >= limit.monthly_limit:
-                return (
-                    jsonify({"error": f"Aylık limit aşıldı: {limit.monthly_limit} / {feature_name}"}),
-                    429,
-                )
-
-            pipe = redis_client.pipeline()
-            pipe.incr(day_key)
-            pipe.expire(day_key, 86400)
-            pipe.incr(month_key)
-            pipe.expire(month_key, 2678400)
-            pipe.execute()
-
-            return f(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
+    return deco
 
 
-def get_usage_count(user, feature):
-    """Return today's usage count for the given feature."""
-    start_of_day = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
-    return (
-        UsageLog.query
-        .filter_by(user_id=user.id, action=feature)
-        .filter(UsageLog.timestamp >= start_of_day)
-        .count()
-    )
+def get_usage_status(user_id: str, feature_key: str) -> Dict:
+    eff = get_user_effective_limits(user_id=user_id, feature_key=feature_key)
+    used = _get_r(user_id, feature_key)
+    if used is None:
+        used = _get_db(user_id, feature_key)
+    pl = _payload(used, int(eff.get("daily_quota", 0)))
+    pl.update({"feature_key": feature_key, "plan_name": eff.get("plan_name")})
+    return pl

--- a/tests/test_limits_status.py
+++ b/tests/test_limits_status.py
@@ -1,0 +1,55 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+
+
+def _noop(*_a, **_k):
+    def wrap(f):
+        return f
+    return wrap
+
+
+def setup_app(monkeypatch):
+    # jwt/limit dekoratörleri no-op
+    monkeypatch.setattr("backend.api.routes.jwt_required", lambda *a, **k: _noop(), raising=False)
+    try:
+        import backend.api.routes as routes
+        setattr(routes, "limiter", SimpleNamespace(limit=lambda *_a, **_k: _noop()))
+    except Exception:
+        pass
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    from backend import create_app
+    from backend.db import db
+    from backend.db.models import User
+    app = create_app()
+    app.config.update(TESTING=True, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+    with app.app_context():
+        db.create_all()
+        u = User(id="u1", email="t@t.t", username="t", password_hash="x", subscription_level="BASIC", is_active=True)
+        db.session.add(u)
+        db.session.commit()
+
+    @app.before_request
+    def _inject_user():
+        from flask import g
+        g.user = SimpleNamespace(id="u1", username="t", subscription_level="BASIC")
+
+    monkeypatch.setattr("backend.api.routes.get_jwt_identity", lambda: "u1", raising=False)
+    return app
+
+
+def test_limits_status_endpoint(monkeypatch):
+    app = setup_app(monkeypatch)
+    client = app.test_client()
+    resp = client.get("/api/limits/status")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["plan"]
+    assert "features" in data
+    assert isinstance(data["features"], dict)


### PR DESCRIPTION
## Summary
- implement dynamic rate limiting derived from user plans
- introduce utilities for plan and usage quota lookups
- expose `/api/limits/status` endpoint and accompanying test

## Testing
- `pytest tests/test_limits_status.py -q` *(fails: connection to PostgreSQL refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d43b6d88832f838aed149d824822