### PR TITLE
Add decision orchestrator consensus API

### DIFF
--- a/backend/api/decision.py
+++ b/backend/api/decision.py
@@ -1,8 +1,21 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, g, current_app
+
+import pandas as pd
+from typing import Any, Dict
 
 from backend.decision_engine import extract_features, make_decision
 from backend.decision_engine.score_calculator import calculate_score
 from backend.engine.strategic_decision_engine import advanced_decision_logic
+from backend.auth.jwt_utils import jwt_required_if_not_testing
+from backend.middleware.plan_limits import enforce_plan_limit
+from backend.utils.feature_flags import feature_flag_enabled
+from backend.utils.logger import create_log
+from backend.decision_engines import (
+    ENGINE_REGISTRY,
+    DecisionRequest,
+    OrchestratorConfig,
+    build_consensus_result,
+)
 
 # Blueprint for lightweight decision endpoints
 decision_bp = Blueprint('decision', __name__, url_prefix='/api/decision')
@@ -43,3 +56,66 @@ def predict_decision():
     coin = data.get("coin", "UNKNOWN")
     result = make_decision(coin, score)
     return jsonify(result)
+
+
+@decision_bp.route('/score-multi', methods=['POST'])
+@jwt_required_if_not_testing()
+@enforce_plan_limit("predict_daily")
+def score_multi():
+    """Çoklu motor çıktısından konsensüs kararı üretir."""
+
+    if not feature_flag_enabled("decision_consensus"):
+        return jsonify({"error": "Özellik şu anda devre dışı."}), 403
+
+    user = g.get("user")
+    ip_addr = request.remote_addr or "unknown"
+    ua = request.headers.get("User-Agent", "")
+    status = "success"
+    try:
+        payload = request.get_json() or {}
+        symbol = payload.get("symbol")
+        timeframe = payload.get("timeframe")
+        engines = payload.get("engines", [])
+        params = payload.get("params", {})
+        account_value = payload.get("account_value")
+
+        df = pd.DataFrame(payload.get("ohlcv", []))
+
+        results: Dict[str, Any] = {}
+        for eid in engines:
+            if eid not in ENGINE_REGISTRY:
+                continue
+            eng_cls = ENGINE_REGISTRY[eid]
+            eng = eng_cls()
+            req = DecisionRequest(
+                engine_id=eid,
+                symbol=symbol,
+                timeframe=timeframe,
+                ohlcv=df,
+                params=params.get(eid, {}),
+            )
+            results[eid] = eng.run(req)
+
+        if not results:
+            return jsonify({"error": "çalıştırılacak motor bulunamadı"}), 400
+
+        consensus = build_consensus_result(
+            symbol, timeframe, df, results, OrchestratorConfig(), account_value
+        )
+        return jsonify(consensus)
+    except Exception as exc:  # pragma: no cover
+        status = "error"
+        current_app.logger.exception("score_multi hata: %s", exc)
+        return jsonify({"error": "internal"}), 500
+    finally:
+        if user:
+            create_log(
+                user_id=str(user.id),
+                username=user.username,
+                ip_address=ip_addr,
+                action="decision_consensus",
+                target="/api/decision/score-multi",
+                description="Konsensüs kararı", 
+                status=status,
+                user_agent=ua,
+            )

--- a/backend/decision_engines/__init__.py
+++ b/backend/decision_engines/__init__.py
@@ -1,0 +1,30 @@
+"""
+Karar motorları paketi.
+Her motor BaseDecisionEngine'den türemeli ve registry'ye kendini kaydetmeli.
+"""
+
+from .registry import ENGINE_REGISTRY, register_engine
+from .base import DecisionRequest, DecisionResult, BaseDecisionEngine
+
+# Orkestratör / rejim kapısı / risk & kalibrasyon yardımcıları
+from .orchestrator import build_consensus_result, OrchestratorConfig
+from .gate import detect_regime
+from .utils import zscore, winsorize01
+
+__all__ = [
+    "ENGINE_REGISTRY",
+    "register_engine",
+    "DecisionRequest",
+    "DecisionResult",
+    "BaseDecisionEngine",
+    "build_consensus_result",
+    "OrchestratorConfig",
+    "detect_regime",
+    "zscore",
+    "winsorize01",
+]
+
+# Motorların import edilmesi (side-effect: registry dolumu)
+# Not: Dosya adları bilinçli kısa tutuldu.
+from .engines import km1, km2, km3, km4  # noqa: F401
+

--- a/backend/decision_engines/base.py
+++ b/backend/decision_engines/base.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+
+@dataclass
+class DecisionRequest:
+    """Karar motoruna iletilen standart istek."""
+
+    engine_id: str
+    symbol: str
+    timeframe: str
+    ohlcv: pd.DataFrame
+    params: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class DecisionResult:
+    """Karar motorunun ürettiği sonuç."""
+
+    engine_id: str
+    action: str
+    confidence: float
+    horizon_days: float
+    expected_return: float
+    stop_loss: float
+    take_profit: float
+    metadata: Dict[str, Any]
+
+
+class BaseDecisionEngine:
+    """Tüm karar motorları için temel sınıf."""
+
+    engine_id: str = "BASE"
+
+    def run(self, request: DecisionRequest) -> DecisionResult:  # pragma: no cover - soyut
+        raise NotImplementedError
+

--- a/backend/decision_engines/engines/__init__.py
+++ b/backend/decision_engines/engines/__init__.py
@@ -1,0 +1,2 @@
+# paket işaretleyici
+

--- a/backend/decision_engines/engines/km1.py
+++ b/backend/decision_engines/engines/km1.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+import numpy as np
+import pandas as pd
+
+from ..registry import register_engine
+from ..base import BaseDecisionEngine, DecisionRequest, DecisionResult
+from ..utils import daily_volatility
+
+
+def _ema(x: pd.Series, span: int) -> pd.Series:
+    return x.ewm(span=span, adjust=False).mean()
+
+
+@register_engine
+class KM1MomentumEMACrossover(BaseDecisionEngine):
+    """
+    KM1: Momentum / EMA crossover (varsayılan: 12/48)
+    Trend gücü = (ema_fast - ema_slow)/close
+    """
+    engine_id = "KM1"
+
+    def run(self, request: DecisionRequest) -> DecisionResult:
+        df = request.ohlcv.copy().sort_values("ts")
+        params: Dict[str, Any] = request.params or {}
+        fast = int(params.get("ema_fast", 12))
+        slow = int(params.get("ema_slow", 48))
+        horizon = float(params.get("horizon_days", 5.0))
+        atr_mult = float(params.get("atr_mult", 1.5))
+
+        close = df["close"].astype(float)
+        ema_fast = _ema(close, fast)
+        ema_slow = _ema(close, slow)
+        trend = (ema_fast - ema_slow) / (close + 1e-12)
+        t = float(trend.iloc[-1]) if len(trend) else 0.0
+
+        cross_up = bool((ema_fast.iloc[-2] <= ema_slow.iloc[-2]) and (ema_fast.iloc[-1] > ema_slow.iloc[-1])) if len(df) > 2 else False
+        cross_dn = bool((ema_fast.iloc[-2] >= ema_slow.iloc[-2]) and (ema_fast.iloc[-1] < ema_slow.iloc[-1])) if len(df) > 2 else False
+
+        action = "hold"
+        if t > 0:
+            action = "buy"
+        if t < 0:
+            action = "sell"
+        if cross_up:
+            action = "buy"
+        if cross_dn:
+            action = "sell"
+
+        conf = float(np.tanh(abs(t) * 100))
+        expected = float(np.clip(t * 5, -0.08, 0.08))
+        dvol = daily_volatility(df)
+        sl = float(-atr_mult * dvol)
+        tp = float(+2.0 * atr_mult * dvol)
+
+        return DecisionResult(
+            engine_id=self.engine_id,
+            action=action,
+            confidence=conf,
+            horizon_days=horizon,
+            expected_return=expected,
+            stop_loss=sl,
+            take_profit=tp,
+            metadata={
+                "trend": t,
+                "cross_up": cross_up,
+                "cross_dn": cross_dn,
+                "ema_fast": fast,
+                "ema_slow": slow,
+            },
+        )

--- a/backend/decision_engines/engines/km2.py
+++ b/backend/decision_engines/engines/km2.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+import numpy as np
+import pandas as pd
+
+from ..registry import register_engine
+from ..base import BaseDecisionEngine, DecisionRequest, DecisionResult
+from ..utils import daily_volatility
+
+
+def _atr(df: pd.DataFrame, w: int = 14) -> pd.Series:
+    hl = (df["high"] - df["low"]).abs()
+    hc = (df["high"] - df["close"].shift()).abs()
+    lc = (df["low"] - df["close"].shift()).abs()
+    tr = pd.concat([hl, hc, lc], axis=1).max(axis=1)
+    return tr.rolling(int(w)).mean()
+
+
+@register_engine
+class KM2ATRBreakout(BaseDecisionEngine):
+    """
+    KM2: ATR kanal kırılımı (savunmacı)
+    close > MA + k*ATR => buy, close < MA - k*ATR => sell
+    """
+    engine_id = "KM2"
+
+    def run(self, request: DecisionRequest) -> DecisionResult:
+        df = request.ohlcv.copy().sort_values("ts")
+        params: Dict[str, Any] = request.params or {}
+        w = int(params.get("atr_window", 14))
+        ma_w = int(params.get("ma_window", 20))
+        k = float(params.get("atr_k", 1.0))
+        horizon = float(params.get("horizon_days", 4.0))
+
+        close = df["close"].astype(float)
+        ma = close.rolling(ma_w).mean()
+        atr = _atr(df, w)
+        upper = ma + k * atr
+        lower = ma - k * atr
+
+        cu = float(close.iloc[-1]) if len(close) else np.nan
+        up = float(upper.iloc[-1]) if len(upper) else np.nan
+        lo = float(lower.iloc[-1]) if len(lower) else np.nan
+
+        action = "hold"
+        if np.isfinite(cu) and np.isfinite(up) and cu > up:
+            action = "buy"
+        elif np.isfinite(cu) and np.isfinite(lo) and cu < lo:
+            action = "sell"
+
+        dist = 0.0
+        if action == "buy" and np.isfinite(up):
+            dist = (cu - up) / (cu + 1e-12)
+        if action == "sell" and np.isfinite(lo):
+            dist = (lo - cu) / (cu + 1e-12)
+        conf = float(np.clip(np.tanh(abs(dist) * 50), 0.0, 1.0))
+        expected = float(np.clip(dist * 3, -0.06, 0.06))
+
+        dvol = daily_volatility(df)
+        sl = float(-1.2 * dvol)
+        tp = float(+1.8 * dvol)
+
+        return DecisionResult(
+            engine_id=self.engine_id,
+            action=action,
+            confidence=conf,
+            horizon_days=horizon,
+            expected_return=expected,
+            stop_loss=sl,
+            take_profit=tp,
+            metadata={"atr_window": w, "ma_window": ma_w, "atr_k": k},
+        )

--- a/backend/decision_engines/engines/km3.py
+++ b/backend/decision_engines/engines/km3.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+import numpy as np
+import pandas as pd
+
+from ..registry import register_engine
+from ..base import BaseDecisionEngine, DecisionRequest, DecisionResult
+from ..utils import daily_volatility
+
+
+def _rsi(close: pd.Series, period: int = 14) -> pd.Series:
+    delta = close.diff()
+    gain = delta.clip(lower=0.0)
+    loss = (-delta).clip(lower=0.0)
+    avg_gain = gain.ewm(alpha=1.0 / period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1.0 / period, adjust=False).mean()
+    rs = avg_gain / (avg_loss + 1e-12)
+    return 100.0 - (100.0 / (1.0 + rs))
+
+
+@register_engine
+class KM3RSIMeanReversion(BaseDecisionEngine):
+    """
+    KM3: RSI Mean-Reversion
+    RSI<30 => buy, RSI>70 => sell, aksi hold
+    """
+    engine_id = "KM3"
+
+    def run(self, request: DecisionRequest) -> DecisionResult:
+        df = request.ohlcv.copy().sort_values("ts")
+        params: Dict[str, Any] = request.params or {}
+        period = int(params.get("rsi_period", 14))
+        low_th = float(params.get("rsi_low", 30.0))
+        high_th = float(params.get("rsi_high", 70.0))
+        horizon = float(params.get("horizon_days", 3.0))
+
+        close = df["close"].astype(float)
+        rsi = _rsi(close, period)
+        val = float(rsi.iloc[-1]) if len(rsi) else 50.0
+
+        action = "hold"
+        if val < low_th:
+            action = "buy"
+        elif val > high_th:
+            action = "sell"
+
+        dist = 0.0
+        if action == "buy":
+            dist = (low_th - val) / 100.0
+        elif action == "sell":
+            dist = (val - high_th) / 100.0
+        conf = float(np.clip(np.tanh(abs(dist) * 6), 0.0, 1.0))
+        expected = float(np.clip(dist * 4, -0.05, 0.05))
+
+        dvol = daily_volatility(df)
+        sl = float(-1.4 * dvol)
+        tp = float(+1.6 * dvol)
+
+        return DecisionResult(
+            engine_id=self.engine_id,
+            action=action,
+            confidence=conf,
+            horizon_days=horizon,
+            expected_return=expected,
+            stop_loss=sl,
+            take_profit=tp,
+            metadata={"rsi": val, "rsi_period": period},
+        )

--- a/backend/decision_engines/engines/km4.py
+++ b/backend/decision_engines/engines/km4.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from ..registry import register_engine
+from ..base import BaseDecisionEngine, DecisionRequest, DecisionResult
+from ..utils import daily_volatility
+
+
+@register_engine
+class KM4BaselineHold(BaseDecisionEngine):
+    """
+    KM4: Baseline/Hold – her zaman temkinli 'hold' önerir.
+    Konsensüste dengeleyici rol oynar.
+    """
+    engine_id = "KM4"
+
+    def run(self, request: DecisionRequest) -> DecisionResult:
+        df = request.ohlcv
+        dvol = daily_volatility(df)
+        horizon = float((request.params or {}).get("horizon_days", 2.0))
+        return DecisionResult(
+            engine_id=self.engine_id,
+            action="hold",
+            confidence=0.25,
+            horizon_days=horizon,
+            expected_return=0.0,
+            stop_loss=float(-1.0 * dvol),
+            take_profit=float(+1.0 * dvol),
+            metadata={},
+        )

--- a/backend/decision_engines/gate.py
+++ b/backend/decision_engines/gate.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+class RegimeResult(pd.Series):
+    """Rejim tespiti çıktısı."""
+
+    @property
+    def _constructor(self):  # pragma: no cover - pandas için
+        return RegimeResult
+
+
+def _ema(series: pd.Series, span: int) -> pd.Series:
+    return series.ewm(span=span, adjust=False).mean()
+
+
+def detect_regime(ohlcv: pd.DataFrame, atr_window: int = 14) -> RegimeResult:
+    """Trend ve volatiliteye göre basit rejim tespiti."""
+
+    df = ohlcv.copy().sort_values("ts")
+    close = df["close"]
+    ema50 = _ema(close, 50)
+    ema200 = _ema(close, 200)
+    trend = (ema50 - ema200) / (close + 1e-12)
+
+    hl = df["high"] - df["low"]
+    hc = (df["high"] - df["close"].shift()).abs()
+    lc = (df["low"] - df["close"].shift()).abs()
+    tr = np.maximum.reduce([hl.values, hc.values, lc.values])
+    atr = pd.Series(tr, index=df.index).rolling(atr_window).mean()
+    vol_pct = (atr / (close + 1e-12)).fillna(0)
+
+    t = float(trend.iloc[-1]) if len(trend) else 0.0
+    v = float(vol_pct.iloc[-1]) if len(vol_pct) else 0.0
+
+    up = t > 0.002
+    down = t < -0.002
+    low_vol = v < 0.02
+    high_vol = v > 0.04
+
+    if np.isnan(t) or np.isnan(v):
+        label = "mixed"
+    elif up and low_vol:
+        label = "risk_on"
+    elif down and high_vol:
+        label = "risk_off"
+    else:
+        label = "mixed"
+
+    return RegimeResult({"label": label, "trend_strength": t, "vol_pct": v})
+

--- a/backend/decision_engines/orchestrator.py
+++ b/backend/decision_engines/orchestrator.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .registry import ENGINE_REGISTRY
+from .base import DecisionRequest, DecisionResult
+from .utils import action_to_score, zscore, winsorize01, daily_volatility
+from .gate import detect_regime
+
+
+@dataclass
+class OrchestratorConfig:
+    """Orkestrasyon için konfigürasyon."""
+
+    weights_risk_on: Dict[str, float] = field(
+        default_factory=lambda: {"KM1": 0.35, "KM2": 0.15, "KM3": 0.35, "KM4": 0.15}
+    )
+    weights_mixed: Dict[str, float] = field(
+        default_factory=lambda: {"KM1": 0.30, "KM2": 0.30, "KM3": 0.30, "KM4": 0.10}
+    )
+    weights_risk_off: Dict[str, float] = field(
+        default_factory=lambda: {"KM1": 0.15, "KM2": 0.45, "KM3": 0.30, "KM4": 0.10}
+    )
+    vol_target_annual: float = 0.15
+    max_position_fraction: float = 0.02
+
+
+def _pick_weights(cfg: OrchestratorConfig, regime_label: str) -> Dict[str, float]:
+    if regime_label == "risk_on":
+        return cfg.weights_risk_on
+    if regime_label == "risk_off":
+        return cfg.weights_risk_off
+    return cfg.weights_mixed
+
+
+def _normalized_weights(engine_ids: Sequence[str], raw_map: Dict[str, float]) -> np.ndarray:
+    w = np.array([float(raw_map.get(e, 0.0)) for e in engine_ids], dtype=float)
+    s = w.sum()
+    if not np.isfinite(s) or s <= 1e-12:
+        w = np.ones(len(engine_ids), dtype=float)
+        s = float(len(engine_ids))
+    return w / s
+
+
+def _weighted_avg(values: Sequence[float], weights: np.ndarray) -> float:
+    v = np.array([float(x) for x in values], dtype=float)
+    ws = float(weights.sum())
+    if not np.isfinite(ws) or ws <= 1e-12:
+        return float(np.nanmean(v)) if len(v) else 0.0
+    return float(np.average(v, weights=weights))
+
+
+def build_consensus_result(
+    symbol: str,
+    timeframe: str,
+    ohlcv: pd.DataFrame,
+    engine_results: Dict[str, DecisionResult],
+    cfg: OrchestratorConfig,
+    account_value: float | None = None,
+) -> Dict[str, Any]:
+    """Motor çıktılarından rejim-ağırlıklı konsensüs kararı üret."""
+
+    regime = detect_regime(ohlcv)
+    ids: List[str] = list(engine_results.keys())
+    weights = _normalized_weights(ids, _pick_weights(cfg, regime["label"]))
+
+    raw_scores, confs, exp_rets = [], [], []
+    for eid in ids:
+        res = engine_results[eid]
+        raw_scores.append(action_to_score(res.action) * float(res.confidence))
+        confs.append(float(res.confidence))
+        exp_rets.append(float(res.expected_return))
+    raw_scores = winsorize01(np.array(raw_scores, dtype=float), 0.01)
+    norm_scores = zscore(raw_scores)
+
+    s_consensus = float((norm_scores * weights).sum()) if len(norm_scores) else 0.0
+    exp_consensus = float((np.array(exp_rets) * weights).sum()) if len(exp_rets) else 0.0
+    conf_consensus = float((np.array(confs) * weights).sum()) if len(confs) else 0.0
+
+    label = "hold"
+    if s_consensus > 0.15:
+        label = "buy"
+    elif s_consensus < -0.15:
+        label = "sell"
+
+    spread = float(np.nanstd(norm_scores)) if len(norm_scores) else 0.0
+    conf_low = exp_consensus - spread * 0.5
+    conf_high = exp_consensus + spread * 0.5
+
+    dvol = daily_volatility(ohlcv)
+    ann_vol = float(dvol * np.sqrt(252)) if dvol > 0 else 0.0
+    frac = cfg.max_position_fraction
+    if ann_vol > 0:
+        frac = min(cfg.max_position_fraction, cfg.vol_target_annual / (ann_vol + 1e-8))
+    if regime["label"] == "risk_off":
+        frac *= 0.5
+    if exp_consensus <= 0 and label == "buy":
+        frac *= 0.5
+    position_value = float(frac * (account_value or 0.0))
+
+    rationale = [
+        f"{eid}:{engine_results[eid].action}({engine_results[eid].confidence:.2f})"
+        for eid in ids
+    ]
+    top_drivers = sorted(
+        [
+            (
+                eid,
+                abs(action_to_score(engine_results[eid].action))
+                * engine_results[eid].confidence,
+            )
+            for eid in ids
+        ],
+        key=lambda x: x[1],
+        reverse=True,
+    )[:3]
+
+    return {
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "regime": {
+            "label": regime["label"],
+            "trend_strength": regime["trend_strength"],
+            "vol_pct": regime["vol_pct"],
+        },
+        "consensus": {
+            "label": label,
+            "score_raw": s_consensus,
+            "expected_return": exp_consensus,
+            "confidence": conf_consensus,
+            "conf_int": [conf_low, conf_high],
+            "horizon_days": _weighted_avg(
+                [engine_results[e].horizon_days for e in ids], weights
+            ),
+            "position_fraction": frac,
+            "position_value": position_value,
+            "stop_loss": _weighted_avg(
+                [engine_results[e].stop_loss for e in ids], weights
+            ),
+            "take_profit": _weighted_avg(
+                [engine_results[e].take_profit for e in ids], weights
+            ),
+            "rationale": rationale,
+            "top_drivers": [k for k, _ in top_drivers],
+        },
+        "engines": {eid: engine_results[eid].__dict__ for eid in ids},
+    }
+

--- a/backend/decision_engines/registry.py
+++ b/backend/decision_engines/registry.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .base import BaseDecisionEngine
+
+# Motor sınıfları bu registry'ye kaydedilir
+ENGINE_REGISTRY: Dict[str, Type[BaseDecisionEngine]] = {}
+
+
+def register_engine(cls: Type[BaseDecisionEngine]) -> Type[BaseDecisionEngine]:
+    """Karar motorunu ID'siyle registry'ye ekleyen dekoratör."""
+
+    ENGINE_REGISTRY[getattr(cls, "engine_id", cls.__name__)] = cls
+    return cls
+

--- a/backend/decision_engines/utils.py
+++ b/backend/decision_engines/utils.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def zscore(x: np.ndarray, eps: float = 1e-12) -> np.ndarray:
+    """Basit z-skoru hesaplama, boş diziler için güvenli."""
+
+    if x is None or len(x) == 0:
+        return np.array([], dtype=float)
+    m = np.nanmean(x)
+    s = np.nanstd(x)
+    if s < eps:
+        return np.zeros_like(x, dtype=float)
+    return (x - m) / (s + eps)
+
+
+def winsorize01(x: np.ndarray, p: float = 0.01) -> np.ndarray:
+    """0-1 aralığında Winsorize uygular."""
+
+    if x is None or len(x) == 0:
+        return np.array([], dtype=float)
+    lo, hi = np.nanquantile(x, p), np.nanquantile(x, 1 - p)
+    return np.clip(x, lo, hi)
+
+
+def action_to_score(action: str) -> float:
+    """Al/sat/ara kararlarını -1..1 skoruna çevir."""
+
+    a = (action or "").strip().lower()
+    if a in ("buy", "strong_buy", "strongbuy"):
+        return 1.0
+    if a in ("sell", "strong_sell", "strongsell"):
+        return -1.0
+    return 0.0
+
+
+def daily_volatility(ohlcv: pd.DataFrame) -> float:
+    """OHLCV tablosundan günlük volatilite tahmini."""
+
+    if "ts" in ohlcv.columns:
+        ohlcv = ohlcv.sort_values("ts")
+    r = ohlcv["close"].pct_change().dropna()
+    return float(r.std() if len(r) > 5 else 0.0)
+

--- a/backend/utils/feature_flags.py
+++ b/backend/utils/feature_flags.py
@@ -34,6 +34,7 @@ _default_flags: Dict[str, bool] = {
     # DRAKS için hem kısa hem _enabled alias'ı destekleyelim
     "draks": False,
     "draks_enabled": False,
+    "decision_consensus": True,
 
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ nbformat==5.10.4
 nest-asyncio==1.6.0
 networkx==3.3
 notebook_shim==0.2.4
-numpy==2.3.1
+numpy==2.3.1  # Temel bilimsel bağımlılıklar (orchestrator & engines)
 overrides==7.7.0
 packaging==25.0
 pandas==2.3.1

--- a/tests/test_engines_registry.py
+++ b/tests/test_engines_registry.py
@@ -1,0 +1,26 @@
+from backend.decision_engines import ENGINE_REGISTRY
+from backend.decision_engines.base import DecisionRequest
+import pandas as pd
+
+
+def _mk_df(n=120):
+    import numpy as np
+    ts = pd.date_range("2024-01-01", periods=n, freq="H")
+    close = pd.Series(100 + np.cumsum(np.random.normal(0, 0.3, size=n)))
+    high = close + abs(np.random.normal(0, 0.2, size=n))
+    low = close - abs(np.random.normal(0, 0.2, size=n))
+    open_ = close.shift(1).fillna(close.iloc[0])
+    volu = abs(np.random.normal(100, 10, size=n))
+    return pd.DataFrame({"ts": ts, "open": open_, "high": high, "low": low, "close": close, "volume": volu})
+
+
+def test_registry_and_basic_run():
+    for eid in ("KM1", "KM2", "KM3", "KM4"):
+        assert eid in ENGINE_REGISTRY
+    eng = ENGINE_REGISTRY["KM1"]()
+    df = _mk_df()
+    req = DecisionRequest(engine_id="KM1", symbol="BTCUSDT", timeframe="1h", ohlcv=df, params={})
+    res = eng.run(req)
+    assert res.engine_id == "KM1"
+    assert res.action in {"buy", "sell", "hold"}
+    assert 0.0 <= res.confidence <= 1.0

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+from backend.decision_engines.gate import detect_regime
+
+
+def _mk_df(n=300, start=100.0, drift=0.0005, vol=0.01):
+    import numpy as np
+
+    ts = pd.date_range("2024-01-01", periods=n, freq="H")
+    ret = np.random.normal(drift, vol, size=n)
+    close = start * (1 + pd.Series(ret)).cumprod()
+    high = close * (1 + abs(np.random.normal(0, 0.002, size=n)))
+    low = close * (1 - abs(np.random.normal(0, 0.002, size=n)))
+    open_ = close.shift(1).fillna(close.iloc[0])
+    volu = abs(np.random.normal(100, 10, size=n))
+    return pd.DataFrame(
+        {
+            "ts": ts,
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": volu,
+        }
+    )
+
+
+def test_detect_regime_outputs():
+    df = _mk_df()
+    r = detect_regime(df)
+    assert r["label"] in {"risk_on", "risk_off", "mixed"}
+    assert "trend_strength" in r and "vol_pct" in r
+

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,61 @@
+import pandas as pd
+
+from backend.decision_engines.orchestrator import (
+    OrchestratorConfig,
+    build_consensus_result,
+)
+from backend.decision_engines.base import DecisionResult
+
+
+def _mk_df(n=240):
+    import numpy as np
+
+    ts = pd.date_range("2024-01-01", periods=n, freq="H")
+    close = pd.Series(100 + np.cumsum(np.random.normal(0, 0.5, size=n)))
+    high = close + abs(np.random.normal(0, 0.3, size=n))
+    low = close - abs(np.random.normal(0, 0.3, size=n))
+    open_ = close.shift(1).fillna(close.iloc[0])
+    volu = abs(np.random.normal(100, 10, size=n))
+    return pd.DataFrame(
+        {
+            "ts": ts,
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": volu,
+        }
+    )
+
+
+def test_consensus_basic():
+    df = _mk_df()
+    engines = {
+        "E1": DecisionResult(
+            engine_id="E1",
+            action="buy",
+            confidence=0.6,
+            horizon_days=5,
+            expected_return=0.03,
+            stop_loss=-0.02,
+            take_profit=0.06,
+            metadata={},
+        ),
+        "E2": DecisionResult(
+            engine_id="E2",
+            action="hold",
+            confidence=0.4,
+            horizon_days=3,
+            expected_return=0.0,
+            stop_loss=-0.03,
+            take_profit=0.04,
+            metadata={},
+        ),
+    }
+    out = build_consensus_result(
+        "BTCUSDT", "1h", df, engines, OrchestratorConfig(), 100000
+    )
+    assert out["symbol"] == "BTCUSDT"
+    assert "consensus" in out and "label" in out["consensus"]
+    assert out["consensus"]["position_value"] >= 0.0
+


### PR DESCRIPTION
## Summary
- implement decision engine orchestrator, regime gate, and helper utilities
- expose multi-engine consensus endpoint with auth, logging and plan limits
- document orchestrator API and add tests for regime detection and consensus builder
- register sample decision engines and test registry initialization

## Testing
- `pytest tests/test_gate.py tests/test_orchestrator.py tests/test_engines_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab32c6420c832faea6f93165d5f8cf