### PR TITLE
chore: add env examples and dotenv loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 .env.*
 !.env.example
 !.env.production.example
+backend/.env
+backend/.env.*
+!backend/.env.example
+frontend/.env
+frontend/.env.*
+!frontend/.env.example
 
 # Secret files
 *.key

--- a/README.md
+++ b/README.md
@@ -384,3 +384,11 @@ Bu proje MIT lisansı altında sunulmaktadır. Ayrıntılar için `LICENSE` dosy
 bakabilirsiniz.
 
 
+## Secrets & ENV Yönetimi
+
+Üretim ortamında tüm hassas bilgiler GitHub Actions Secrets üzerinden
+yönetilir. Yerel geliştirmede gerekli değerler `.env` dosyalarına yazılır; bu
+dosyalar depoya eklenmez ve `.gitignore` tarafından korunur. Örnek
+konfigürasyonlar için `*.env.example` dosyalarına bakabilirsiniz.
+
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+FLASK_ENV=development
+DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+REDIS_URL=redis://localhost:6379/0
+JWT_ALG=HS512
+JWT_SECRET=__SET_IN_RUNTIME__
+SECURITY_CORS_ALLOWED_ORIGINS=http://localhost:3000

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -29,8 +29,6 @@ from backend.models.plan import Plan  # noqa: F401 (kullanıldığı modüller o
 from backend.models.admin_test_run import AdminTestRun  # noqa: F401
 from backend.utils.usage_limits import check_usage_limit
 
-load_dotenv()
-
 # -----------------------------------------------------------------------------
 # Ortak yardımcılar / config
 # -----------------------------------------------------------------------------
@@ -149,6 +147,8 @@ class LegacyTestClient(FlaskClient):
 # App Factory
 # -----------------------------------------------------------------------------
 def create_app() -> Flask:
+    if os.getenv("FLASK_ENV") != "production":
+        load_dotenv()
     app = Flask(__name__)
     app.test_client_class = LegacyTestClient
     app.config.from_object(Config)

--- a/backend/tests/test_env_loading.py
+++ b/backend/tests/test_env_loading.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+import backend
+
+
+def test_load_dotenv_called_when_not_production(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "development")
+    with patch("backend.load_dotenv") as mock_load:
+        backend.create_app()
+        mock_load.assert_called_once()
+
+
+def test_load_dotenv_skipped_in_production(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "production")
+    with patch("backend.load_dotenv") as mock_load:
+        backend.create_app()
+        mock_load.assert_not_called()

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:5000


### PR DESCRIPTION
## Summary
- ignore env files and add example templates
- load dotenv only outside production
- document secrets management

## Testing
- `pytest` *(fails: assert 500 in (200, 202, 201, 204))*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5841a49c832f865208b5daae1014