### PR TITLE
Add security headers and JWT-aware rate limiting

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -7,6 +7,8 @@ import logging
 from .logging_config import configure_json_logging
 from .middleware.request_id import request_id_middleware
 from .health import bp as health_bp
+from .security import security_headers
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 
 def create_app(config_object: str | None = None) -> Flask:
@@ -22,6 +24,13 @@ def create_app(config_object: str | None = None) -> Flask:
 
     # --- Request-ID middleware ---
     request_id_middleware(app)
+
+    # --- Güvenlik başlıkları ---
+    security_headers(app)
+
+    # --- ProxyFix ---
+    if os.getenv("ENABLE_PROXY_FIX", "false").lower() == "true":
+        app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1)
 
     # --- Blueprints ---
     app.register_blueprint(health_bp)

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,19 @@
+import os
+
+
+def security_headers(app):
+    """Temel güvenlik başlıklarını ekle."""
+    csp = os.getenv("SECURITY_CSP", "default-src 'self';")
+
+    @app.after_request
+    def _add_headers(resp):
+        # HSTS
+        resp.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains; preload"
+        # Clickjacking ve MIME sniffing korumaları
+        resp.headers["X-Frame-Options"] = "DENY"
+        resp.headers["X-Content-Type-Options"] = "nosniff"
+        # Referrer gizliliği
+        resp.headers["Referrer-Policy"] = "no-referrer"
+        # İçerik güvenlik politikası (override edilebilir)
+        resp.headers["Content-Security-Policy"] = csp
+        return resp

--- a/tests/test_backend_security_headers.py
+++ b/tests/test_backend_security_headers.py
@@ -1,0 +1,12 @@
+from backend.app import create_app
+
+
+def test_security_headers_present():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/health")
+    assert resp.headers["Strict-Transport-Security"] == "max-age=31536000; includeSubDomains; preload"
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["Referrer-Policy"] == "no-referrer"
+    assert resp.headers["Content-Security-Policy"] == "default-src 'self';"

--- a/tests/test_limiting_helpers.py
+++ b/tests/test_limiting_helpers.py
@@ -5,23 +5,22 @@ from backend.limiting import get_plan_rate_limit, rate_limit_key_func
 
 def test_get_plan_rate_limit_defaults(app):
     with app.app_context():
-        assert get_plan_rate_limit(None) == "30/minute"
+        assert get_plan_rate_limit(None) == "30 per minute"
 
 
 def test_get_plan_rate_limit_env_override(monkeypatch):
     monkeypatch.setitem(limiting.DEFAULT_PLAN_LIMITS, "basic", "99/minute")
-    assert get_plan_rate_limit("basic") == "99/minute"
+    assert get_plan_rate_limit("basic") == "99 per minute"
 
 
-def test_rate_limit_key_func_user(app):
+def test_rate_limit_key_func_user(app, monkeypatch):
+    monkeypatch.setattr(limiting, "verify_jwt_in_request", lambda optional=True: None)
+    monkeypatch.setattr(limiting, "get_jwt", lambda: {"sub": "42"})
     with app.test_request_context("/"):
-        g.user_id = 42
         assert rate_limit_key_func() == "user:42"
 
 
 def test_rate_limit_key_func_ip(app):
     with app.test_request_context("/", environ_overrides={"REMOTE_ADDR": "7.8.9.1"}):
-        if hasattr(g, "user_id"):
-            del g.user_id
         assert rate_limit_key_func() == "ip:7.8.9.1"
 


### PR DESCRIPTION
## Summary
- enforce standard security headers via middleware
- enable optional ProxyFix support
- derive rate limit keys from JWT subject or client IP

## Testing
- `pytest tests/test_limiting_helpers.py tests/test_backend_security_headers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab5f224a48832f9fbbf82751f76ecf