### PR TITLE
ci: cache backend deps and unify security checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            backend/requirements.txt
       - run: |
           python -m pip install -U pip
           pip install ruff==0.6.9 mypy
@@ -76,10 +79,16 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            backend/requirements.txt
       - name: Install deps
         run: |
           python -m pip install -U pip
+          # Sıra önemli: kök -> backend -> dev
           pip install -r requirements.txt
+          pip install -r backend/requirements.txt
+          pip install -r requirements-dev.txt
           pip install pytest pytest-cov
       - name: Run tests
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,19 +14,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: '3.12', cache: 'pip' }
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            backend/requirements.txt
       - run: |
           python -m pip install -U pip
-          pip install -r requirements.txt
+          # Hem kök hem backend bağımlılıklarını denetle
+          pip install -r requirements.txt -r backend/requirements.txt
           pip install pip-audit bandit cyclonedx-bom
-      - name: pip-audit (fail on high)
+      - name: pip-audit (root)
         run: pip-audit -r requirements.txt --failure-severity high
+      - name: pip-audit (backend)
+        run: pip-audit -r backend/requirements.txt --failure-severity high
       - name: Bandit
         run: bandit -r backend -ll
-      - name: Generate SBOM (CycloneDX)
-        run: cyclonedx-py --evidence --format json --outfile sbom.json
+      - name: Generate SBOM (CycloneDX, merged)
+        run: |
+          # Tek SBOM dosyasında birleştirilmiş bağımlılıklar
+          cyclonedx-py --evidence --format json --outfile sbom.json -r requirements.txt -r backend/requirements.txt
       - uses: actions/upload-artifact@v4
-        with: { name: sbom, path: sbom.json }
+        with:
+          name: sbom
+          path: sbom.json
 
   docker_scan:
     runs-on: ubuntu-latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,12 @@
 FROM python:3.12-slim AS builder
 WORKDIR /app
 ENV PIP_NO_CACHE_DIR=1
-COPY requirements.txt .
-RUN python -m pip install --upgrade pip && pip wheel -w /wheels -r requirements.txt
+# Hem kök hem backend gereksinimleri için wheel oluştur
+COPY requirements.txt /tmp/req.root.txt
+COPY backend/requirements.txt /tmp/req.backend.txt
+RUN python -m pip install --upgrade pip \
+ && pip wheel -w /wheels -r /tmp/req.root.txt \
+ && pip wheel -w /wheels -r /tmp/req.backend.txt
 COPY . .
 
 FROM python:3.12-slim


### PR DESCRIPTION
## Summary
- cache Python deps for root and backend in CI and security workflows
- install root, backend, dev requirements in backend test job
- build wheels for root and backend reqs in backend Dockerfile

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/security.yml backend/Dockerfile`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pythonjsonlogger')*


------
https://chatgpt.com/codex/tasks/task_e_68b864994760832fb0cbcc670703e05a