### PR TITLE
feat: add API key support with advanced rate limiting

### DIFF
--- a/backend/admin/__init__.py
+++ b/backend/admin/__init__.py
@@ -1,0 +1,3 @@
+from .routes_rate_limit import admin_bp
+
+__all__ = ["admin_bp"]

--- a/backend/admin/routes_rate_limit.py
+++ b/backend/admin/routes_rate_limit.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import ipaddress
+
+from flask import Blueprint, g, jsonify, request
+
+from backend.extensions import redis_client
+from backend.models import db
+from backend.models.api_key import APIKey
+
+admin_bp = Blueprint("admin_rl", __name__, url_prefix="/admin")
+
+
+def admin_required(fn):
+    """Placeholder admin check; replace with real RBAC."""
+
+    def wrapper(*args, **kwargs):
+        if not getattr(g, "user_id", None):
+            return jsonify({"error": "auth required"}), 401
+        return fn(*args, **kwargs)
+
+    wrapper.__name__ = fn.__name__
+    return wrapper
+
+
+@admin_bp.get("/rate-limits/stats")
+@admin_required
+def stats():
+    if not redis_client:
+        return jsonify({"redis": "down"}), 500
+    total_banned = len(list(redis_client.scan_iter(match="banned_ip:*")))
+    return jsonify({"banned_ips": total_banned})
+
+
+@admin_bp.get("/api-keys")
+@admin_required
+def list_keys():
+    keys = APIKey.query.filter_by(user_id=g.user_id).all()
+    return jsonify({"api_keys": [k.to_dict() for k in keys]})
+
+
+@admin_bp.post("/api-keys")
+@admin_required
+def create_key():
+    from backend.auth.api_keys import APIKeyManager
+
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify({"error": "name required"}), 400
+    rl = data.get("rate_limit_override")
+    api_key, kid = APIKeyManager.create_api_key(g.user_id, name, rl)
+    return jsonify({"api_key": api_key, "key_id": kid, "warning": "Store it now"}), 201
+
+
+@admin_bp.delete("/api-keys/<int:key_id>")
+@admin_required
+def delete_key(key_id: int):
+    rec = APIKey.query.filter_by(id=key_id, user_id=g.user_id).first()
+    if not rec:
+        return jsonify({"error": "not found"}), 404
+    rec.is_active = False
+    db.session.commit()
+    return jsonify({"ok": True})
+
+
+@admin_bp.post("/rate-limits/unban-ip")
+@admin_required
+def unban_ip():
+    ip = (request.get_json() or {}).get("ip")
+    try:
+        ipaddress.ip_address(ip)
+    except Exception:
+        return jsonify({"error": "invalid ip"}), 400
+    deleted = 0
+    if redis_client:
+        deleted = redis_client.delete(f"banned_ip:{ip}")
+    return jsonify({"deleted": int(deleted)})

--- a/backend/auth/api_keys.py
+++ b/backend/auth/api_keys.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import secrets
+from datetime import datetime, timedelta
+from functools import wraps
+
+from flask import g, jsonify, request
+
+from backend.extensions import limiter
+from backend.models import db
+from backend.models.api_key import APIKey
+
+
+class APIKeyManager:
+    """Utility for managing API keys."""
+
+    @staticmethod
+    def generate_api_key() -> str:
+        return secrets.token_urlsafe(32)
+
+    @staticmethod
+    def hash_api_key(api_key: str) -> bytes:
+        salt = os.getenv("API_KEY_SALT", "change-me").encode()
+        return hashlib.pbkdf2_hmac("sha256", api_key.encode(), salt, 200_000)
+
+    @staticmethod
+    def verify_api_key(api_key: str, hashed: bytes) -> bool:
+        return hmac.compare_digest(APIKeyManager.hash_api_key(api_key), hashed)
+
+    @staticmethod
+    def create_api_key(
+        user_id: int,
+        name: str,
+        rate_limit_override: str | None = None,
+        expires_at: datetime | None = None,
+    ) -> tuple[str, int]:
+        api_key = APIKeyManager.generate_api_key()
+        key_hash = APIKeyManager.hash_api_key(api_key)
+        if expires_at is None:
+            expires_at = datetime.utcnow() + timedelta(days=365)
+        rec = APIKey(
+            user_id=user_id,
+            name=name,
+            key_hash=key_hash,
+            rate_limit_override=rate_limit_override,
+            expires_at=expires_at,
+            is_active=True,
+        )
+        db.session.add(rec)
+        db.session.commit()
+        return api_key, rec.id
+
+    @staticmethod
+    def validate_api_key(api_key: str | None) -> APIKey | None:
+        if not api_key:
+            return None
+        for rec in APIKey.query.filter_by(is_active=True).all():
+            if APIKeyManager.verify_api_key(api_key, rec.key_hash):
+                if rec.expires_at and rec.expires_at < datetime.utcnow():
+                    return None
+                rec.last_used_at = datetime.utcnow()
+                rec.usage_count = (rec.usage_count or 0) + 1
+                db.session.commit()
+                return rec
+        return None
+
+
+def require_api_key(fn):
+    """Decorator to require a valid API key."""
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        api_key = request.headers.get("X-API-Key") or request.headers.get(
+            "Authorization"
+        )
+        if api_key and api_key.startswith("Bearer "):
+            api_key = api_key[7:]
+        rec = APIKeyManager.validate_api_key(api_key)
+        if not rec:
+            return jsonify({"error": "API key required"}), 401
+        g.api_key = rec
+        g.user_id = rec.user_id
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def limit_by_api_key(default_limit: str):
+    """Apply dynamic rate limit based on API key configuration."""
+
+    def dynamic_limit() -> str:
+        if hasattr(g, "api_key") and g.api_key and g.api_key.rate_limit_override:
+            return g.api_key.rate_limit_override
+        return default_limit
+
+    def decorator(fn):
+        return limiter.limit(dynamic_limit)(fn)
+
+    return decorator

--- a/backend/config/.env.development
+++ b/backend/config/.env.development
@@ -1,0 +1,18 @@
+# Development ortamı
+# NOT: Gizli değerleri .env yerine Docker secrets ile verin (bkz. /secrets klasörü).
+YTD_ENV=development
+YTD_DEBUG=true
+YTD_CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+YTD_RATE_LIMIT_DEFAULT=200/minute
+YTD_RATE_LIMIT_LOGIN=10/minute
+YTD_RATE_LIMIT_HEADERS_ENABLED=true
+YTD_RATE_LIMIT_STRATEGY=fixed-window-elastic-expiry
+YTD_RATE_LIMIT_WHITELIST=127.0.0.1,::1
+YTD_AUTO_BAN_THRESHOLD=200
+YTD_AUTO_BAN_DURATION_SECONDS=86400
+# Aşağıdakiler docker secrets ile de verilebilir:
+# YTD_SECRET_KEY=dev-please-change
+# YTD_JWT_SECRET=dev-please-change
+# YTD_DATABASE_URL=postgresql+psycopg2://user:pass@localhost:5432/ytd
+# YTD_REDIS_URL=redis://localhost:6379/0
+

--- a/backend/extensions.py
+++ b/backend/extensions.py
@@ -1,0 +1,85 @@
+"""Centralized initialization for Flask extensions."""
+
+from __future__ import annotations
+
+import ipaddress
+
+import redis
+from flask import g, request
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+from .settings import get_settings
+
+redis_client: redis.Redis | None = None
+limiter: Limiter | None = None
+
+
+def _is_whitelisted(ip: str) -> bool:
+    """Return True if IP address is in whitelist."""
+    s = get_settings()
+    for item in s.rate_limit_whitelist:
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            if "/" in item:
+                if ipaddress.ip_address(ip) in ipaddress.ip_network(item, strict=False):
+                    return True
+            elif ip == item:
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def _is_banned(ip: str) -> bool:
+    """Return True if IP address is currently banned."""
+    global redis_client
+    if not redis_client:
+        return False
+    return bool(redis_client.get(f"banned_ip:{ip}"))
+
+
+def client_identity() -> str:
+    """Determine client identity for rate limiting."""
+    ip = get_remote_address()
+    if ip and (_is_whitelisted(ip) or _is_banned(ip)):
+        pass
+    if hasattr(g, "api_key") and getattr(g.api_key, "id", None):
+        return f"api:{g.api_key.id}"
+    if hasattr(g, "user_id") and g.user_id:
+        return f"user:{g.user_id}"
+    return ip or "anonymous"
+
+
+def init_extensions(app) -> None:
+    """Initialize Redis and Limiter within application context."""
+    global redis_client, limiter
+    s = get_settings()
+    redis_client = redis.from_url(
+        str(s.redis_url), socket_timeout=5, retry_on_timeout=True
+    )
+    limiter = Limiter(
+        key_func=client_identity,
+        storage_uri=str(s.redis_url),
+        strategy=s.rate_limit_strategy,
+        default_limits=[s.rate_limit_default],
+        headers_enabled=s.rate_limit_headers_enabled,
+        swallow_errors=True,
+    )
+    limiter.init_app(app)
+
+    @limiter.request_filter
+    def _whitelist_filter() -> bool:  # noqa: WPS430
+        ip = get_remote_address()
+        return bool(ip and _is_whitelisted(ip))
+
+    @limiter.request_filter
+    def _health_and_docs() -> bool:  # noqa: WPS430
+        p = request.path or ""
+        return (
+            p in ("/healthz", "/readyz")
+            or p.startswith("/static/")
+            or p.startswith("/docs")
+        )

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,4 +1,5 @@
 from .admin_test_run import AdminTestRun
+from .api_key import APIKey
 from .log import Log
 from .pending_plan import PendingPlan
 from .plan import Plan
@@ -7,6 +8,7 @@ from .price_history import PriceHistory
 from .promo_code import PromoCode
 
 __all__ = [
+    "APIKey",
     "Plan",
     "PromoCode",
     "PendingPlan",

--- a/backend/models/api_key.py
+++ b/backend/models/api_key.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from backend.db import db
+
+
+class APIKey(db.Model):
+    __tablename__ = "api_keys"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    key_hash = db.Column(db.LargeBinary, nullable=False)
+    rate_limit_override = db.Column(db.String(50))
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
+    expires_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    last_used_at = db.Column(db.DateTime)
+    usage_count = db.Column(db.Integer, default=0, nullable=False)
+
+    user = db.relationship("User", backref=db.backref("api_keys", lazy=True))
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "is_active": self.is_active,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "last_used_at": (
+                self.last_used_at.isoformat() if self.last_used_at else None
+            ),
+            "usage_count": self.usage_count,
+            "rate_limit_override": self.rate_limit_override,
+        }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,4 @@ pytz>=2023.3
 python-dateutil>=2.8.0
 bleach>=6.0.0
 pydantic[email]>=2.8.0
+psutil>=5.9.8

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from functools import lru_cache
+from typing import List, Optional
+
+from pydantic import AnyUrl, Field, SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application configuration using Pydantic Settings."""
+
+    # General
+    env: str = Field(
+        default="development", description="development|staging|production"
+    )
+    debug: bool = False
+    config_version: int = 2
+    config_hash: str = ""
+
+    # Security / JWT
+    secret_key: SecretStr
+    jwt_secret: SecretStr
+    jwt_key_version: int = 1
+
+    # Service connections
+    database_url: AnyUrl
+    redis_url: AnyUrl
+
+    # CORS & rate limit
+    cors_allow_origins: List[str] = Field(default_factory=lambda: ["*"])
+    rate_limit_default: str = "200/minute"
+    rate_limit_login: str = "10/minute"
+    rate_limit_headers_enabled: bool = True
+    rate_limit_strategy: str = "fixed-window-elastic-expiry"
+    rate_limit_whitelist: List[str] = Field(default_factory=list)
+
+    # Misuse / ban
+    auto_ban_threshold: int = 200
+    auto_ban_duration_seconds: int = 86400
+
+    # Model configuration
+    model_config = SettingsConfigDict(
+        env_prefix="YTD_",
+        secrets_dir="/run/secrets",
+        extra="ignore",
+        validate_default=True,
+    )
+
+    @classmethod
+    @lru_cache
+    def load(cls, env: Optional[str] = None) -> "Settings":
+        env = env or os.getenv("YTD_ENV", "development")
+        s = cls(_env_file=f"backend/config/.env.{env}", _env_file_encoding="utf-8")
+        s.env = env
+        payload = (
+            f"{s.env}|{s.rate_limit_default}|{s.rate_limit_login}|v{s.config_version}"
+        )
+        s.config_hash = hashlib.sha256(payload.encode()).hexdigest()[:12]
+        return s
+
+
+def get_settings() -> Settings:
+    """Cached accessor for application settings."""
+    return Settings.load()

--- a/migrations/versions/20250903_add_api_keys.py
+++ b/migrations/versions/20250903_add_api_keys.py
@@ -1,0 +1,40 @@
+"""add api_keys table
+
+Revision ID: 20250903_add_api_keys
+Revises:
+Create Date: 2025-09-03
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20250903_add_api_keys"
+down_revision = "20250901_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("key_hash", sa.LargeBinary(), nullable=False),
+        sa.Column("rate_limit_override", sa.String(length=50)),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column("expires_at", sa.DateTime()),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("last_used_at", sa.DateTime()),
+        sa.Column("usage_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.Index("idx_api_keys_user_id", "user_id"),
+        sa.Index("idx_api_keys_active", "is_active"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("api_keys")


### PR DESCRIPTION
## Summary
- add configurable settings and redis-backed limiter
- implement API key model and admin management routes
- include psutil dependency and environment defaults

## Testing
- `pre-commit run --files backend/requirements.txt backend/config/.env.development backend/settings.py backend/extensions.py backend/models/api_key.py backend/models/__init__.py backend/auth/api_keys.py backend/admin/__init__.py backend/admin/routes_rate_limit.py migrations/versions/20250903_add_api_keys.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b888ffb28c832fba81516ee0ae0557