### PR TITLE
feat: wire admin dashboard sse client

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,3 +8,11 @@ Yeni admin sayfası:
 - Result listesi: `/api/draks/batch/results/{jobId}` filtreleriyle
 
 Giriş için JWT + (opsiyonel) API key gereklidir.
+
+## Gerçek zamanlı yönetim akışı
+
+- `/assets/admin.js` otomatik olarak `/api/admin/dashboard/stream` uç noktasına bir Server-Sent Events (SSE) bağlantısı açar.
+- Bağlantı oluşturulurken erişim jetonu sırasıyla `localStorage`, `sessionStorage` ve çerezlerden okunur ve `?token=` parametresi olarak URL'ye eklenir.
+- Bağlantı durumu ve gelen veriler `oq:sse`, `oq:sse:open`, `oq:sse:message`, `oq:sse:error`, `oq:sse:reconnecting` ve `oq:sse:close` özel olaylarıyla yayınlanır; dinleyiciler hem `window` hem de `document` üzerinde çalışır.
+- Hata durumunda bağlantı 1 saniyeden başlayıp 30 saniyeye kadar artan aralıklarla otomatik olarak yeniden denenir ve jeton değişikliklerinde bağlantı yeniden başlatılır.
+- `window.__oqAdminSSE` denetleyicisi elle yeniden bağlanma (`reconnect()`), bağlantıyı kesme (`disconnect()`) ve anlık durum (`state`) sorguları için kullanılabilir.

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -1,0 +1,7 @@
+# Frontend test notları
+
+## Admin SSE davranışı
+
+- `frontend/assets/admin.js`, admin paneli yüklendiğinde `/api/admin/dashboard/stream` için bir `EventSource` başlatır.
+- Testlerde bu modül yükleniyorsa `window.EventSource` ve `CustomEvent` nesnelerini stub'lamak veya `oq:sse` olaylarını dinlemek gerekir. Her olay, hem `window` hem de `document` üzerinde `oq:sse` ve aşama bazlı (`oq:sse:open`, `oq:sse:message`, vb.) olarak yayınlanır.
+- SSE istemcisi jetonu `localStorage` → `sessionStorage` → çerez sırası ile çözümler ve `?token=` parametresi olarak ekler; hata durumlarında bağlantı 1–30 saniye aralığında artan gecikmelerle yeniden kurulur. Bu davranış, testlerde beklenen yan etkileri (ör. yeniden bağlanma sayaçları) simüle etmek için dikkate alınmalıdır.


### PR DESCRIPTION
## Summary
- bootstrap the admin dashboard bundle with an EventSource client that resolves auth tokens from storage/cookies, forwards oq:sse events, and retries with backoff on errors
- document the SSE behaviour for admins in the frontend README and frontend tests notes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce95c8b0ec832fb73c3ab75809eaa4