### PR TITLE
test: add adaptable smoke tests and fixtures

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,13 @@
 [pytest]
+minversion = 7.0
 testpaths = tests
 python_files = test_*.py
-addopts = 
-    -v 
-    --tb=short 
+addopts =
+    -v
+    -ra
+    --tb=short
     --disable-warnings
+    --strict-markers
     --ignore=scripts/test
     --ignore=tests/test_decision.py.bak
     --ignore=tests/test_health.py.bak
@@ -19,7 +22,20 @@ addopts =
     --ignore=tests/test_promotion_codes_crud.py.bak
     --ignore=tests/test_secure_logging.py.bak
     --ignore=tests/test_ta_insight.py.bak
-env = 
+filterwarnings =
+    ignore::DeprecationWarning
+env =
     TESTING=1
     FLASK_ENV=testing
     SKIP_HEAVY_IMPORTS=1
+markers =
+    unit: Birim testleri
+    integration: Entegrasyon testleri
+    functional: İşlevsel/E2E odaklı testler
+    api: API odaklı testler
+    db: Veritabanı odaklı testler
+    celery: Celery odaklı testler
+    redis: Redis odaklı testler
+    admin: Admin panel akışları
+    payment: Ödeme akışları
+    e2e: Uçtan uca akışlar

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,117 @@
-# Test ortamı için güvenli varsayılanlar (CI ve lokal)
-import os
+"""Global pytest fixtures and environment setup for OrcaQuant."""
 
-# İzole ve yan etkisiz bir test DB'si
+from __future__ import annotations
+
+import contextlib
+import importlib
+import os
+import random
+import string
+from typing import Dict
+
+import pytest
+
+# Provide safe defaults before any test module imports application code.
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("FLASK_ENV", "testing")
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 
-# Burada bilerek herhangi bir app fixture'ı oluşturmadık;
-# projedeki testler backend.create_app vb. kendi akışını çağırıyorsa
-# bu env değişkenleri yeterli olur. İleride ihtiyaç olursa
-# app fixture'ı ekleyebiliriz.
+
+@pytest.fixture(autouse=True, scope="session")
+def _global_random_seed() -> None:
+    """Ensure reproducible randomness across the suite."""
+    random.seed(1337)
+
+
+@pytest.fixture(scope="session")
+def set_test_env() -> None:
+    """Apply deterministic environment overrides for the test session."""
+    env_overrides: Dict[str, str] = {
+        "FLASK_ENV": "testing",
+        "ENV": "testing",
+        "JWT_SECRET_KEY": "test-secret-key",
+        "DATABASE_URL": os.getenv("DATABASE_URL", "sqlite:///:memory:"),
+        "REDIS_URL": os.getenv("REDIS_URL", "redis://localhost:6379/0"),
+        "CELERY_TASK_ALWAYS_EAGER": "1",
+    }
+    previous: Dict[str, str | None] = {key: os.environ.get(key) for key in env_overrides}
+    os.environ.update(env_overrides)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@pytest.fixture(scope="session")
+def app(set_test_env):  # type: ignore[override]
+    """Attempt to create the Flask application for tests.
+
+    If the application factory or its dependencies are unavailable, skip
+    tests requiring the ``app`` fixture instead of failing the suite.
+    """
+
+    with contextlib.suppress(Exception):
+        backend_app = importlib.import_module("backend.app")
+        create_app = getattr(backend_app, "create_app", None)
+        if callable(create_app):
+            return create_app()
+    pytest.skip("Flask app bulunamadı (backend.app.create_app). App gerektiren testler atlanıyor.")
+
+
+@pytest.fixture()
+def client(app):  # type: ignore[override]
+    """Return a Flask test client when the app fixture is available."""
+    return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def faker():  # type: ignore[override]
+    """Provide a localized Faker instance when the dependency exists."""
+    try:
+        from faker import Faker
+    except ImportError:  # pragma: no cover
+        pytest.skip("faker paketi eksik (pip install Faker)")
+    return Faker("tr_TR")
+
+
+@pytest.fixture(scope="session")
+def redis_client():  # type: ignore[override]
+    """Return an isolated Redis client backed by fakeredis when available."""
+    try:
+        import fakeredis
+    except ImportError:  # pragma: no cover
+        pytest.skip("fakeredis paketi eksik (pip install fakeredis)")
+    return fakeredis.FakeStrictRedis()
+
+
+@pytest.fixture(scope="session")
+def celery_app():  # type: ignore[override]
+    """Return the Celery app if defined under ``backend.tasks``.
+
+    Tests are skipped when Celery is not configured in this environment.
+    """
+
+    with contextlib.suppress(Exception):
+        tasks_mod = importlib.import_module("backend.tasks")
+        c_app = getattr(tasks_mod, "celery_app", None)
+        if c_app:
+            return c_app
+    pytest.skip("Celery app bulunamadı (backend.tasks.celery_app).")
+
+
+@pytest.fixture()
+def monkeypatch_env(monkeypatch):  # type: ignore[override]
+    """Expose the builtin monkeypatch fixture for explicit environment tweaks."""
+    return monkeypatch
+
+
+@pytest.fixture()
+def auth_header_token() -> Dict[str, str]:
+    """Generate a simple fake bearer token for tests."""
+    token = "test-" + "".join(random.choices(string.ascii_letters + string.digits, k=24))
+    return {"Authorization": f"Bearer {token}"}

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable fixtures and helpers for the OrcaQuant test-suite."""

--- a/tests/fixtures/adapter.py
+++ b/tests/fixtures/adapter.py
@@ -1,0 +1,92 @@
+"""Helpers to adapt optional backend APIs for the lightweight test-suite."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import types
+from typing import Any, Callable, Dict
+
+import pytest
+
+
+def _import_optional(modname: str):
+    try:
+        return importlib.import_module(modname)
+    except Exception:  # pragma: no cover - missing optional deps
+        return None
+
+
+def get_jwt_api():
+    """Locate JWT helper primitives if the module can be imported."""
+
+    mod = _import_optional("backend.auth.jwt_utils")
+    if not mod:
+        pytest.skip("backend.auth.jwt_utils bulunamadı.")
+
+    token_manager = getattr(mod, "TokenManager", None)
+    generate_tokens = getattr(token_manager, "generate_tokens", None) if token_manager else None
+
+    if not (token_manager and callable(generate_tokens)):
+        pytest.skip("jwt_utils içinde beklenen TokenManager.generate_tokens API'i bulunamadı.")
+
+    return types.SimpleNamespace(module=mod, token_manager=token_manager)
+
+
+def get_services_api():
+    """Inspect backend.core.services for exportable callables."""
+
+    mod = _import_optional("backend.core.services")
+    if not mod:
+        pytest.skip("backend.core.services bulunamadı.")
+
+    callables: Dict[str, Callable[..., Any]] = {
+        name: obj for name, obj in inspect.getmembers(mod, inspect.isfunction)
+    }
+    if not callables:
+        pytest.skip("services içinde testlenecek fonksiyon yok görünüyor.")
+
+    return types.SimpleNamespace(module=mod, fns=callables)
+
+
+def get_models_api():
+    """Collect SQLAlchemy models defined in backend.db.models."""
+
+    mod = _import_optional("backend.db.models")
+    if not mod:
+        pytest.skip("backend.db.models bulunamadı.")
+
+    db = getattr(mod, "db", None)
+    if db is None:
+        try:
+            from backend.db import db as global_db  # type: ignore import-not-found
+        except Exception:  # pragma: no cover - missing optional deps
+            pytest.skip("SQLAlchemy db nesnesi bulunamadı (backend.db.db).")
+        else:
+            db = global_db
+
+    models = {
+        name: obj
+        for name, obj in vars(mod).items()
+        if inspect.isclass(obj) and getattr(obj, "__tablename__", None)
+    }
+    if not models:
+        pytest.skip("Modülde tabloya karşılık gelen SQLAlchemy modeli bulunamadı.")
+
+    return types.SimpleNamespace(module=mod, db=db, models=models)
+
+
+def get_helpers_api():
+    """Return helper functions declared in backend.utils.helpers."""
+
+    mod = _import_optional("backend.utils.helpers")
+    if not mod:
+        pytest.skip("backend.utils.helpers bulunamadı.")
+
+    functions: Dict[str, Callable[..., Any]] = {
+        name: obj for name, obj in vars(mod).items() if callable(obj)
+    }
+    if not functions:
+        pytest.skip("helpers içinde testlenecek fonksiyon yok.")
+
+    return types.SimpleNamespace(module=mod, fns=functions)

--- a/tests/fixtures/fake_data.py
+++ b/tests/fixtures/fake_data.py
@@ -1,0 +1,27 @@
+"""Synthetic payload generators for functional tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict
+
+
+def user_payload(index: int = 1) -> Dict[str, str]:
+    return {
+        "email": f"user{index}@example.com",
+        "password": "Sifre!234",
+        "full_name": f"Test Kullanıcı {index}",
+    }
+
+
+def login_payload(index: int = 1) -> Dict[str, str]:
+    return {"email": f"user{index}@example.com", "password": "Sifre!234"}
+
+
+def prediction_payload(symbol: str = "BTCUSDT") -> Dict[str, object]:
+    return {"symbol": symbol, "horizon_days": 30, "risk_level": "medium"}
+
+
+def exp_pair(seconds: int = 1) -> tuple[datetime, datetime]:
+    now = datetime.utcnow()
+    return now, now + timedelta(seconds=seconds)

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,0 +1,1 @@
+"""Functional test package."""

--- a/tests/functional/test_admin_flow.py
+++ b/tests/functional/test_admin_flow.py
@@ -1,0 +1,15 @@
+"""Functional smoke tests for admin-related endpoints."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.functional, pytest.mark.admin]
+
+
+def test_admin_users_list(app, client):
+    if not any(str(rule.rule).startswith("/api/admin/users") for rule in app.url_map.iter_rules()):
+        pytest.skip("Admin users ucu bulunamadı.")
+
+    response = client.get("/api/admin/users")
+    assert response.status_code in (200, 401, 403)

--- a/tests/functional/test_payment_flow.py
+++ b/tests/functional/test_payment_flow.py
@@ -1,0 +1,15 @@
+"""Functional payment flow smoke tests."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.functional, pytest.mark.payment]
+
+
+def test_payment_flow_smoke(app, client):
+    if not any(str(rule.rule).startswith("/api/pay") for rule in app.url_map.iter_rules()):
+        pytest.skip("Ödeme uçları tanımlı değil.")
+
+    response = client.post("/api/pay/checkout", json={"plan": "pro"})
+    assert response.status_code in (200, 201, 202)

--- a/tests/functional/test_user_flow.py
+++ b/tests/functional/test_user_flow.py
@@ -1,0 +1,35 @@
+"""End-to-end style flow covering registration, login, prediction, and logout."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fixtures.fake_data import login_payload, prediction_payload, user_payload
+
+pytestmark = [pytest.mark.functional, pytest.mark.e2e]
+
+
+def _missing_routes(app, paths):
+    return [path for path in paths if not any(str(rule.rule).startswith(path) for rule in app.url_map.iter_rules())]
+
+
+def test_user_register_login_predict_logout(app, client):
+    required = ["/api/auth/register", "/api/auth/login", "/api/predict", "/api/auth/logout"]
+    missing = _missing_routes(app, required)
+    if missing:
+        pytest.skip(f"Flow için eksik uçlar: {missing}")
+
+    response = client.post("/api/auth/register", json=user_payload(2))
+    assert response.status_code in (200, 201, 409)
+
+    response = client.post("/api/auth/login", json=login_payload(2))
+    assert response.status_code in (200, 201)
+    token = (response.get_json() or {}).get("access_token")
+    assert token
+
+    headers = {"Authorization": f"Bearer {token}"}
+    response = client.post("/api/predict", json=prediction_payload("ETHUSDT"), headers=headers)
+    assert response.status_code in (200, 202)
+
+    response = client.post("/api/auth/logout", headers=headers)
+    assert response.status_code in (200, 204)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration test package."""

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -1,0 +1,45 @@
+"""Integration-level smoke tests for HTTP endpoints."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fixtures.fake_data import login_payload, prediction_payload, user_payload
+
+pytestmark = [pytest.mark.integration, pytest.mark.api]
+
+
+def _has_endpoint(app, rule_prefix: str) -> bool:
+    return any(str(rule.rule).startswith(rule_prefix) for rule in app.url_map.iter_rules())
+
+
+def test_auth_endpoints(app, client):
+    required = ["/api/auth/register", "/api/auth/login", "/api/auth/logout"]
+    missing = [endpoint for endpoint in required if not _has_endpoint(app, endpoint)]
+    if missing:
+        pytest.skip(f"Eksik auth uçları: {missing}")
+
+    response = client.post("/api/auth/register", json=user_payload(1))
+    assert response.status_code in (200, 201, 409)
+
+    response = client.post("/api/auth/login", json=login_payload(1))
+    assert response.status_code in (200, 201)
+    token = (response.get_json() or {}).get("access_token")
+    assert token
+
+
+def test_api_prediction(app, client):
+    if not _has_endpoint(app, "/api/predict"):
+        pytest.skip("Prediction ucu bulunamadı /api/predict")
+
+    response = client.post("/api/predict", json=prediction_payload("BTCUSDT"))
+    assert response.status_code in (200, 202)
+    assert response.get_json() is not None
+
+
+def test_admin_panel_endpoints(app, client):
+    if not _has_endpoint(app, "/api/admin"):
+        pytest.skip("Admin panel API kökü yok /api/admin")
+
+    response = client.get("/api/admin/users")
+    assert response.status_code in (200, 401, 403)

--- a/tests/integration/test_celery_tasks.py
+++ b/tests/integration/test_celery_tasks.py
@@ -1,0 +1,22 @@
+"""Smoke tests for Celery task registration."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.celery]
+
+
+POSSIBLE_TASK_NAMES = [
+    "backend.tasks.celery_tasks.run_full_analysis",
+    "backend.tasks.plan_tasks.enqueue_plan_refresh",
+    "backend.tasks.ml_tasks.train_prediction_model",
+]
+
+
+def test_celery_tasks_registered(celery_app):
+    registered = [name for name in POSSIBLE_TASK_NAMES if name in celery_app.tasks]
+    if not registered:
+        pytest.skip(f"Celery task bulunamadı: {POSSIBLE_TASK_NAMES}")
+    for name in registered:
+        assert callable(celery_app.tasks[name])

--- a/tests/integration/test_db_ops.py
+++ b/tests/integration/test_db_ops.py
@@ -1,0 +1,49 @@
+"""Integration tests for database operations using SQLAlchemy."""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+from tests.fixtures.adapter import get_models_api
+
+pytestmark = [pytest.mark.integration, pytest.mark.db]
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    return app
+
+
+def test_transaction_commit_rollback():
+    api = get_models_api()
+    model = api.models.get("User") or next(iter(api.models.values()), None)
+    if model is None:
+        pytest.skip("Veritabanı modeli bulunamadı.")
+
+    app = _make_app()
+    api.db.init_app(app)
+    with app.app_context():
+        api.db.drop_all()
+        api.db.create_all()
+
+        try:
+            instance = model(
+                username="txn-user",
+                email="txn@example.com",
+                password_hash="hashed",
+                api_key="api-key-2",
+            ) if hasattr(model, "username") else model()
+        except Exception as exc:  # pragma: no cover - model specific requirements
+            pytest.skip(f"Model örneği oluşturulamadı: {exc}")
+
+        api.db.session.add(instance)
+        api.db.session.commit()
+
+        api.db.session.delete(instance)
+        api.db.session.rollback()
+
+        remaining = api.db.session.query(model).first()
+        assert remaining is not None

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -1,0 +1,13 @@
+"""Integration checks for Redis-like operations."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.redis]
+
+
+def test_redis_basic_set_get(redis_client):
+    key, value = "k1", "v1"
+    assert redis_client.set(key, value)
+    assert redis_client.get(key).decode() == value

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit test package."""

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,0 +1,26 @@
+"""Unit tests for helper utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fixtures.adapter import get_helpers_api
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_helpers_importable():
+    api = get_helpers_api()
+    assert api.fns
+
+
+def test_sanitize_dict_removes_control_characters():
+    api = get_helpers_api()
+    sanitize_dict = api.fns.get("sanitize_dict")
+    if sanitize_dict is None:
+        pytest.skip("sanitize_dict fonksiyonu bulunamadı.")
+
+    dirty = {"key\n": "value\t"}
+    clean = sanitize_dict(dirty)
+    assert "\n" not in next(iter(clean.keys()))
+    assert "\t" not in next(iter(clean.values()))

--- a/tests/unit/test_jwt_utils.py
+++ b/tests/unit/test_jwt_utils.py
@@ -1,0 +1,52 @@
+"""Unit tests targeting lightweight JWT helpers."""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+import jwt
+
+from tests.fixtures.adapter import get_jwt_api
+
+pytestmark = [pytest.mark.unit]
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    app.config["JWT_SECRET_KEY"] = "test-secret-key"
+    app.config.setdefault("SECRET_KEY", "test-secret-key")
+    return app
+
+
+def test_token_manager_is_available():
+    api = get_jwt_api()
+    assert hasattr(api.token_manager, "generate_tokens")
+
+
+def test_generate_tokens_produces_access_and_refresh():
+    api = get_jwt_api()
+    app = _make_app()
+    with app.app_context():
+        tokens = api.token_manager.generate_tokens(user_id=1, additional_claims={"username": "demo"})
+    assert tokens["access_token"]
+    assert tokens["refresh_token"]
+    assert tokens["access_token"] != tokens["refresh_token"]
+    assert tokens["access_expires"] < tokens["refresh_expires"]
+
+
+def test_generate_tokens_include_custom_claims():
+    api = get_jwt_api()
+    app = _make_app()
+    with app.app_context():
+        tokens = api.token_manager.generate_tokens(user_id=7, additional_claims={"username": "tester"})
+        access_token = tokens["access_token"]
+
+    payload = jwt.decode(
+        access_token,
+        app.config["JWT_SECRET_KEY"],
+        algorithms=["HS256"],
+        audience="orcaquant-users",
+        issuer="orcaquant-app",
+    )
+    assert payload["username"] == "tester"
+    assert payload["user_id"] == 7

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,53 @@
+"""Unit-level smoke tests for SQLAlchemy models."""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+from tests.fixtures.adapter import get_models_api
+
+pytestmark = [pytest.mark.unit, pytest.mark.db]
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    return app
+
+
+def test_models_metadata_tables_create():
+    api = get_models_api()
+    app = _make_app()
+    api.db.init_app(app)
+    with app.app_context():
+        api.db.drop_all()
+        api.db.create_all()
+        assert api.db.Model.metadata.tables
+
+
+def test_user_model_insert_roundtrip():
+    api = get_models_api()
+    user_model = api.models.get("User")
+    if user_model is None:
+        pytest.skip("User modeli bulunamadı.")
+
+    app = _make_app()
+    api.db.init_app(app)
+    with app.app_context():
+        api.db.drop_all()
+        api.db.create_all()
+
+        user = user_model(
+            username="unit-user",
+            email="u1@example.com",
+            password_hash="hashed",
+            api_key="api-key-1",
+        )
+        api.db.session.add(user)
+        api.db.session.commit()
+
+        fetched = user_model.query.filter_by(username="unit-user").first()
+        assert fetched is not None
+        assert fetched.email == "u1@example.com"

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,27 @@
+"""Lightweight sanity checks for ``backend.core.services``."""
+
+from __future__ import annotations
+
+import pytest
+from requests import Session
+
+from tests.fixtures.adapter import get_services_api
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_services_module_importable():
+    api = get_services_api()
+    assert api.module is not None
+    assert api.fns
+
+
+def test_http_client_session_is_singleton():
+    api = get_services_api()
+    http_client = getattr(api.module, "HTTPClient", None)
+    if http_client is None:
+        pytest.skip("HTTPClient sınıfı bulunamadı.")
+    first = http_client.session()
+    second = http_client.session()
+    assert isinstance(first, Session)
+    assert first is second


### PR DESCRIPTION
## Summary
- expand pytest configuration with stricter marker definitions and warning filters
- add shared fixtures plus lightweight adapters for optional backend dependencies
- introduce unit, integration, and functional smoke tests that skip cleanly when requirements are missing

## Testing
- pytest tests/unit/test_jwt_utils.py -k generate -q
- pytest tests/integration/test_redis.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd88bd6ac0832fb112cda8a997a39b