### PR TITLE
fix: align dependency files and local setup with actual imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Yerel Python ortamıyla geliştirme:
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt -r backend/requirements.txt -r requirements-ml.txt -r requirements-dev.txt
 cp .env.example .env    # anahtarları doldurun
 
 # DB hazırla (ilk kurulum)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,6 @@ marshmallow==3.21.1
 werkzeug>=3.0.0
 types-requests; python_version>="3.9"
 cachetools>=5.3.3
+numpy>=2.0,<3.0
+pandas>=2.2,<3.0
+bleach>=6.1,<7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,10 @@ prometheus-client>=0.16,<1.0
 # Realtime (kullanıyorsan bırak; kullanmıyorsan ikisini kaldır)
 Flask-SocketIO>=5.3,<6.0
 eventlet>=0.33,<0.34
+numpy>=2.0,<3.0
+pandas>=2.2,<3.0
+bleach>=6.1,<7.0
+pandas-ta>=0.3.14b,<0.4
 
 # Admin SPA dependencies
 itsdangerous==2.2.0      # CSRF token üretimi (admin)


### PR DESCRIPTION
### Motivation
- Project code imports `numpy`, `pandas`, `bleach` and `pandas-ta` in multiple backend modules but these were not declared consistently in the dependency manifests, causing test/runtime import errors. 
- Local setup instructions did not instruct installing the ML/backend/dev requirement files together which can leave environments partially provisioned. 

### Description
- Added `numpy`, `pandas`, and `bleach` to `backend/requirements.txt` to match backend module imports. 
- Added `numpy`, `pandas`, `bleach`, and `pandas-ta` to top-level `requirements.txt` so a standard install covers ML/analysis code paths. 
- Updated the README local setup command to install `requirements.txt`, `backend/requirements.txt`, `requirements-ml.txt`, and `requirements-dev.txt` in one step. 

### Testing
- Ran `pytest -q` to reproduce the original collection failures and confirm dependency-related import errors during test collection, which showed missing `pandas`, `numpy`, `bleach`, and `factory_boy`. 
- Attempted `pip install -r backend/requirements.txt -r requirements-dev.txt` and `pip install pandas numpy bleach factory_boy` but installation failed due to package index/network restrictions (HTTP 403/tunnel errors) in the execution environment. 
- After the manifest updates, the repository dependency files are consistent with runtime imports so environments with normal PyPI access should be able to install dependencies and run the test suite successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e37d56b68832f9bc4b277f158b36c)